### PR TITLE
Standarized formatting and added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/C-examples/C++/lists/genericList/List.cc
+++ b/C-examples/C++/lists/genericList/List.cc
@@ -16,32 +16,34 @@ template<class myType> bool List<myType>::isEmpty()
 
 template<class myType> void List<myType>::print()
 {
-	if (isEmpty()) 
-    	cout << "List is empty";
-    Node<myType> *current = head;
-    while (current != NULL) {
-        cout << (*current).toString() << "\n";
-        current = (*current).getNext();
-    }
+	if (isEmpty())
+		cout << "List is empty";
+	Node<myType> *current = head;
+	while (current != NULL)
+	{
+		cout << (*current).toString() << "\n";
+		current = (*current).getNext();
+	}
 }//print
 
 template<class myType> void List<myType>::insertAtFront(myType *obj)
 {
-   Node<myType> *current =  new Node<myType>(obj);
-   (*current).setNext(head);
-   head = current;
+	Node<myType> *current =  new Node<myType>(obj);
+	(*current).setNext(head);
+	head = current;
 }
 
 template<class myType> void List<myType>::insertAtRear(myType *obj)
 {
-	if (isEmpty()) 
-    	head = new Node<myType>(obj);
-	else {
-    	Node<myType> *current = head;          // Start at head of list
-    	while ((*current).getNext() != NULL) // Find the end of the list
-        	current = (*current).getNext();
-    	(*current).setNext(new Node<myType>(obj));  // Insert the newNode
-	}      
+	if (isEmpty())
+		head = new Node<myType>(obj);
+	else
+	{
+		Node<myType> *current = head;          // Start at head of list
+		while ((*current).getNext() != NULL) // Find the end of the list
+			current = (*current).getNext();
+		(*current).setNext(new Node<myType>(obj));  // Insert the newNode
+	}
 }
 
 template<class myType> Node<myType>  *List<myType>::removeFirst()
@@ -53,22 +55,24 @@ template<class myType> Node<myType>  *List<myType>::removeFirst()
 
 template<class myType> Node<myType>  *List<myType>::removeLast()
 {
-    if (isEmpty())  // empty list
-        return NULL;
-     
-    Node<myType> *current = head;
-    if ((*current).getNext() == NULL) {     // Singleton list
-        head = NULL;
-        return current;
-    }
-     
-    Node<myType> *previous = NULL;                // All other cases
-    while ((*current).getNext() != NULL) {
-        previous = current;
-        current = (*current).getNext();
-    }
-    (*previous).setNext(NULL);
-    return current;
+	if (isEmpty())  // empty list
+		return NULL;
+
+	Node<myType> *current = head;
+	if ((*current).getNext() == NULL)       // Singleton list
+	{
+		head = NULL;
+		return current;
+	}
+
+	Node<myType> *previous = NULL;                // All other cases
+	while ((*current).getNext() != NULL)
+	{
+		previous = current;
+		current = (*current).getNext();
+	}
+	(*previous).setNext(NULL);
+	return current;
 }//removeLast
 
 // vim: set tabstop=4:

--- a/C-examples/C++/lists/genericList/Node.cc
+++ b/C-examples/C++/lists/genericList/Node.cc
@@ -5,7 +5,7 @@
 
 	Implementation of the Node class.
 */
-		
+
 template<class T> Node<T>::Node(T *obj)
 {
 	data = obj;
@@ -36,4 +36,4 @@ template<class T> Node<T> *Node<T>::getNext()
 {
 	return next;
 }
-		
+

--- a/C-examples/C++/lists/genericList/main.cc
+++ b/C-examples/C++/lists/genericList/main.cc
@@ -5,38 +5,38 @@
 #include "PhoneRecord.h"
 
 
-    /**
-     * main() creates a linked list of different types of objects
-     *   and tests this class's methods. This example shows that
-     *   a single list can store different types of objects.
-     */ 
-    int main(int argc, char* argv[])
-	{
-		typedef List<PhoneRecord> PhoneList;
-        // Create list and insert heterogeneous nodes
-        PhoneList list;
-        list.insertAtFront(new PhoneRecord("Bob M", "997-0020"));
-        list.insertAtRear(new PhoneRecord("Jane M", "997-2101"));
-        list.insertAtRear(new PhoneRecord("Scott K", "997-2517"));
+/**
+ * main() creates a linked list of different types of objects
+ *   and tests this class's methods. This example shows that
+ *   a single list can store different types of objects.
+ */
+int main(int argc, char* argv[])
+{
+	typedef List<PhoneRecord> PhoneList;
+	// Create list and insert heterogeneous nodes
+	PhoneList list;
+	list.insertAtFront(new PhoneRecord("Bob M", "997-0020"));
+	list.insertAtRear(new PhoneRecord("Jane M", "997-2101"));
+	list.insertAtRear(new PhoneRecord("Scott K", "997-2517"));
 
-                    // Print the list
-        cout << "Generic List" << "\n";
-        list.print();
-        // Remove objects and print resulting list
-		/*
-        Object o;
-        o = list.removeLast();
-        System.out.println(" Removed " + o.toString());
-        System.out.println("Generic List:");
-        list.print();
-        o = list.removeLast();
-        System.out.println(" Removed " + o.toString());
-        System.out.println("Generic List:");
-        list.print();
-        o = list.removeFirst();
-        System.out.println(" Removed " +o.toString());
-        System.out.println("Generic List:");
-        list.print();
-		*/
-    } // main()
+	// Print the list
+	cout << "Generic List" << "\n";
+	list.print();
+	// Remove objects and print resulting list
+	/*
+	Object o;
+	o = list.removeLast();
+	System.out.println(" Removed " + o.toString());
+	System.out.println("Generic List:");
+	list.print();
+	o = list.removeLast();
+	System.out.println(" Removed " + o.toString());
+	System.out.println("Generic List:");
+	list.print();
+	o = list.removeFirst();
+	System.out.println(" Removed " +o.toString());
+	System.out.println("Generic List:");
+	list.print();
+	*/
+} // main()
 

--- a/C-examples/C++/lists/phonelist/List.cc
+++ b/C-examples/C++/lists/phonelist/List.cc
@@ -16,32 +16,34 @@ bool List::isEmpty()
 
 void List::print()
 {
-	if (isEmpty()) 
-    	cout << "List is empty" << endl;
-    Node *current = head;
-    while (current != NULL) {
-        cout << current->toString() << "\n";
-        current = current->getNext();
-    }
+	if (isEmpty())
+		cout << "List is empty" << endl;
+	Node *current = head;
+	while (current != NULL)
+	{
+		cout << current->toString() << "\n";
+		current = current->getNext();
+	}
 }//print
 
 void List::insertAtFront(PhoneRecord *obj)
 {
-   Node *current =  new Node(obj);
-   current->setNext(head);
-   head = current;
+	Node *current =  new Node(obj);
+	current->setNext(head);
+	head = current;
 }
 
 void List::insertAtRear(PhoneRecord *obj)
 {
-	if (isEmpty()) 
-    	head = new Node(obj);
-	else {
-    	Node *current = head;          // Start at head of list
-    	while (current->getNext() != NULL) // Find the end of the list
-        	current = current->getNext();
-    	current->setNext(new Node(obj));  // Insert the newNode
-	}      
+	if (isEmpty())
+		head = new Node(obj);
+	else
+	{
+		Node *current = head;          // Start at head of list
+		while (current->getNext() != NULL) // Find the end of the list
+			current = current->getNext();
+		current->setNext(new Node(obj));  // Insert the newNode
+	}
 }
 
 Node  *List::removeFirst()
@@ -53,22 +55,24 @@ Node  *List::removeFirst()
 
 Node  *List::removeLast()
 {
-    if (isEmpty())  // empty list
-        return NULL;
-     
-    Node *current = head;
-    if (current->getNext() == NULL) {     // Singleton list
-        head = NULL;
-        return current;
-    }
-     
-    Node *previous = NULL;                // All other cases
-    while (current->getNext() != NULL) {
-        previous = current;
-        current = (*current).getNext();
-    }
-    previous->setNext(NULL);
-    return current;
+	if (isEmpty())  // empty list
+		return NULL;
+
+	Node *current = head;
+	if (current->getNext() == NULL)       // Singleton list
+	{
+		head = NULL;
+		return current;
+	}
+
+	Node *previous = NULL;                // All other cases
+	while (current->getNext() != NULL)
+	{
+		previous = current;
+		current = (*current).getNext();
+	}
+	previous->setNext(NULL);
+	return current;
 }//removeLast
 
 // vim: set tabstop=4:

--- a/C-examples/C++/lists/phonelist/Node.cc
+++ b/C-examples/C++/lists/phonelist/Node.cc
@@ -5,35 +5,35 @@
 
 	Implementation of the Node class.
 */
-		
- Node::Node(PhoneRecord *obj)
+
+Node::Node(PhoneRecord *obj)
 {
 	data = obj;
 	next = NULL; // defined to be the value 0
 }
 
- void Node::setData(PhoneRecord *obj)
+void Node::setData(PhoneRecord *obj)
 {
 	data = obj;
 }
 
- PhoneRecord *Node::getData()
+PhoneRecord *Node::getData()
 {
 	return data;
 }
 
- string Node::toString()
+string Node::toString()
 {
 	return  data->toString();
 }
 
- void Node::setNext(Node *nextPtr)
+void Node::setNext(Node *nextPtr)
 {
 	next = nextPtr;
 }
 
- Node *Node::getNext()
+Node *Node::getNext()
 {
 	return next;
 }
-		
+

--- a/C-examples/C++/lists/phonelist/main.cc
+++ b/C-examples/C++/lists/phonelist/main.cc
@@ -11,35 +11,35 @@ using namespace std;
  * main() creates a linked list of different types of objects
  *   and tests this class's methods. This example shows that
  *   a single list can store different types of objects.
- */ 
+ */
 int main(int argc, char* argv[])
 {
-    // Create list and insert heterogeneous nodes
-    List list; 
+	// Create list and insert heterogeneous nodes
+	List list;
 	/*List *list = new List();*/
 
-    list.insertAtFront(new PhoneRecord("Bob M", "997-0020"));
-    list.insertAtRear(new PhoneRecord("Jane M", "997-2101"));
-    list.insertAtRear(new PhoneRecord("Scott K", "997-2517"));
+	list.insertAtFront(new PhoneRecord("Bob M", "997-0020"));
+	list.insertAtRear(new PhoneRecord("Jane M", "997-2101"));
+	list.insertAtRear(new PhoneRecord("Scott K", "997-2517"));
 
-                // Print the list
-    cout << "Generic List" << "\n";
-    list.print();
-    // Remove objects and print resulting list
-    Node *node;
-    node = list.removeLast();
-    cout << " Removed " + node->toString() << endl;
-    cout << "The List:" << endl;
-    list.print();
+	// Print the list
+	cout << "Generic List" << "\n";
+	list.print();
+	// Remove objects and print resulting list
+	Node *node;
+	node = list.removeLast();
+	cout << " Removed " + node->toString() << endl;
+	cout << "The List:" << endl;
+	list.print();
 
-    node = list.removeLast();
-    cout << " Removed " + node->toString() << endl;
-    cout << "The List:" << endl;
-    list.print();
+	node = list.removeLast();
+	cout << " Removed " + node->toString() << endl;
+	cout << "The List:" << endl;
+	list.print();
 
-    node = list.removeFirst();
-    cout << " Removed " + node->toString() << endl;
-    cout << "The List:" << endl;
-    list.print();
+	node = list.removeFirst();
+	cout << " Removed " + node->toString() << endl;
+	cout << "The List:" << endl;
+	list.print();
 } // main()
 

--- a/C-examples/C++/lists/template/MyClass.cc
+++ b/C-examples/C++/lists/template/MyClass.cc
@@ -8,5 +8,5 @@ template<class T> MyClass<T>::MyClass(void)
 
 template<class T> void MyClass<T>::print(T obj)
 {
-		cout << obj << endl;
+	cout << obj << endl;
 }

--- a/C-examples/C++/mergesort/TimeMergeSort.cc
+++ b/C-examples/C++/mergesort/TimeMergeSort.cc
@@ -34,24 +34,24 @@ void printArray(int *a, int n)
 
 
 int main(int argc, char *argv[])
-{  
-  	if (argc == 1)
-  	{
+{
+	if (argc == 1)
+	{
 		cerr << "Usage: java MergeSortTime <n> \n";
 		exit(1);
-  	}
-  	int n = atoi(argv[1]);
+	}
+	int n = atoi(argv[1]);
 
-   	// construct random array
-   	int* a = randomIntArray(n, 100);
-      
+	// construct random array
+	int* a = randomIntArray(n, 100);
+
 	/*printArray(a, n);*/
 
 	long startTime = getCurrentTimeMillis();
-   	MergeSort::sort(a, n);
+	MergeSort::sort(a, n);
 	long totalTime = getCurrentTimeMillis() - startTime;
 
-   	cout << "Elapsed time: " << totalTime/1000.0 << " seconds" << endl;
+	cout << "Elapsed time: " << totalTime/1000.0 << " seconds" << endl;
 
 	/*printArray(a, n);*/
 }//main

--- a/C-examples/C++/primes/Primes.cc
+++ b/C-examples/C++/primes/Primes.cc
@@ -18,7 +18,7 @@ using namespace std;
 
 class Primes
 {
-	public:
+public:
 
 	/**
 		Check if input parameter is prime or not.
@@ -27,7 +27,7 @@ class Primes
 	*/
 	static bool isPrime(long n)
 	{
-	    // take care of simple cases first
+		// take care of simple cases first
 		if ((n == 1) || (n ==2))
 			return true;
 
@@ -54,7 +54,7 @@ class Primes
 		Faster prime factorization method.
 	*/
 	static string primeFactorization(long n)
-	{	
+	{
 		// simple cases
 		if (n == 1) return "1";
 		if (isPrime(n)) return Utility::itos(n) + "";
@@ -62,13 +62,13 @@ class Primes
 		string result = "";
 		long sqrtn = (long) ceil(sqrt((double)n));
 		long number = n;
-		
+
 		// see how many times 2 divides into n
 		while (number % 2 == 0)
 		{
 			result = result + Utility::itos(2);
 			number = number/2;
-			if (number != 1) 
+			if (number != 1)
 				result = result + " * ";
 		}
 
@@ -83,20 +83,20 @@ class Primes
 					/*cout << result << endl;;*/
 					result = result + Utility::itos(i);
 					number = number/i;
-					if (number != 1) 
+					if (number != 1)
 						result = result + " * ";
 				}
 			}
 			if (number == 1) break;
 			if (isPrime(number)) break;
 		}
-		if (number > 1) 
+		if (number > 1)
 			result = result + Utility::itos(number);
 		return result;
 	}
 
 
-};	
+};
 
 
 int main (int argc, char * argv[])

--- a/C-examples/C++/simpleExamples/demo2.cc
+++ b/C-examples/C++/simpleExamples/demo2.cc
@@ -22,8 +22,8 @@ int main(int argc, char *argv[])
 
 	// A character can be appended to a string but not more than one
 	// character at a time (other types are not promoted to string type)
-	s1 += 'a'; 
-	s1 += ' '; 
+	s1 += 'a';
+	s1 += ' ';
 	s1 += 'b';
 
 	cout << s1+ " " + s2 << endl;
@@ -39,17 +39,17 @@ int main(int argc, char *argv[])
 	// A dynamically allocated array
 	int *A = new int[COUNT];
 	for (int i=0; i<COUNT; i++)
-		A[i] = i;  
+		A[i] = i;
 
 	delete [] A; //free up the space used by the array
 
 	A = new int[2*COUNT];
 	for (int i=0; i<2*COUNT; i++)
-		A[i] = i;  
+		A[i] = i;
 
 	delete [] A; //free up the space used by the array
 
-	// while loops, do-while loops, if statements, for loops are 
+	// while loops, do-while loops, if statements, for loops are
 	// the same as Java
 	int i=0;
 	while (i < COUNT)
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 
 	// read in a bunch of strings until end of input
 	vector<String> *temp = new vector<String>();
-	
+
 	String nextWord;
 
 	cout << "Type in strings and end with Control-d" << endl;
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
 	while (!cin.eof())
 	{
 		(*temp).insert((*temp).end(), nextWord);
-		// The -> operator is a convenient shorthand for (*temp). 
+		// The -> operator is a convenient shorthand for (*temp).
 		// temp->insert(temp->end(), nextWord);
 		cin >> nextWord;
 		// use getline(cin, nextWord) to read one line at a time
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 	String * data = new String[vectorSize];
 	for (int i=0; i<vectorSize; i++)
 		data[i] = (*temp)[i];
-	
+
 	// print out the string
 	cout << "printing the string array" << endl;
 	for (int i=0; i<vectorSize; i++)

--- a/C-examples/C++/simpleExamples/demo3.cc
+++ b/C-examples/C++/simpleExamples/demo3.cc
@@ -13,5 +13,5 @@ int main(int argc, char *argv[])
 	cout << "size of float = " << sizeof(float)*BITS <<  " bits. " << endl;
 	cout << "size of double = " << sizeof(double)*BITS <<  " bits. " << endl;
 	cout << "size of long long = " << sizeof(long long)*BITS <<  " bits."
-	<< endl;
+	     << endl;
 }

--- a/C-examples/C++/simpleExamples/hello.cc
+++ b/C-examples/C++/simpleExamples/hello.cc
@@ -4,5 +4,5 @@ using namespace std;
 
 int main(int argc, char *argv[])
 {
-		cout << "hello world" << "\n";
+	cout << "hello world" << "\n";
 }

--- a/C-examples/C++/stack/List.cc
+++ b/C-examples/C++/stack/List.cc
@@ -16,32 +16,34 @@ bool List::isEmpty()
 
 void List::print()
 {
-	if (isEmpty()) 
-    	cout << "List is empty" << endl;
-    Node *current = head;
-    while (current != NULL) {
-        cout << current->toString() << "\n";
-        current = current->getNext();
-    }
+	if (isEmpty())
+		cout << "List is empty" << endl;
+	Node *current = head;
+	while (current != NULL)
+	{
+		cout << current->toString() << "\n";
+		current = current->getNext();
+	}
 }//print
 
 void List::insertAtFront(char *obj)
 {
-   Node *current =  new Node(obj);
-   current->setNext(head);
-   head = current;
+	Node *current =  new Node(obj);
+	current->setNext(head);
+	head = current;
 }
 
 void List::insertAtRear(char *obj)
 {
-	if (isEmpty()) 
-    	head = new Node(obj);
-	else {
-    	Node *current = head;          // Start at head of list
-    	while (current->getNext() != NULL) // Find the end of the list
-        	current = current->getNext();
-    	current->setNext(new Node(obj));  // Insert the newNode
-	}      
+	if (isEmpty())
+		head = new Node(obj);
+	else
+	{
+		Node *current = head;          // Start at head of list
+		while (current->getNext() != NULL) // Find the end of the list
+			current = current->getNext();
+		current->setNext(new Node(obj));  // Insert the newNode
+	}
 }
 
 Node  *List::removeFirst()
@@ -53,22 +55,24 @@ Node  *List::removeFirst()
 
 Node  *List::removeLast()
 {
-    if (isEmpty())  // empty list
-        return NULL;
-     
-    Node *current = head;
-    if (current->getNext() == NULL) {     // Singleton list
-        head = NULL;
-        return current;
-    }
-     
-    Node *previous = NULL;                // All other cases
-    while (current->getNext() != NULL) {
-        previous = current;
-        current = (*current).getNext();
-    }
-    previous->setNext(NULL);
-    return current;
+	if (isEmpty())  // empty list
+		return NULL;
+
+	Node *current = head;
+	if (current->getNext() == NULL)       // Singleton list
+	{
+		head = NULL;
+		return current;
+	}
+
+	Node *previous = NULL;                // All other cases
+	while (current->getNext() != NULL)
+	{
+		previous = current;
+		current = (*current).getNext();
+	}
+	previous->setNext(NULL);
+	return current;
 }//removeLast
 
 // vim: set tabstop=4:

--- a/C-examples/C++/stack/Node.cc
+++ b/C-examples/C++/stack/Node.cc
@@ -5,7 +5,7 @@
 
 	Implementation of the Node class.
 */
-		
+
 Node::Node(char *obj)
 {
 	data = obj;
@@ -28,13 +28,13 @@ string Node::toString()
 	return  *s;
 }
 
- void Node::setNext(Node *nextPtr)
+void Node::setNext(Node *nextPtr)
 {
 	next = nextPtr;
 }
 
- Node *Node::getNext()
+Node *Node::getNext()
 {
 	return next;
 }
-		
+

--- a/C-examples/C++/stack/TestStack.cc
+++ b/C-examples/C++/stack/TestStack.cc
@@ -7,28 +7,29 @@
  * main() creates a linked list of different types of objects
  *   and tests this class's methods. This example shows that
  *   a single list can store different types of objects.
- */ 
+ */
 int main(int argc, char* argv[])
 {
-    Stack *stack = new Stack();
-    string s = "Hello this is a test string";
+	Stack *stack = new Stack();
+	string s = "Hello this is a test string";
 
-    cout << "String: " + s << endl;
-    for (unsigned int k = 0; k < s.length(); k++)
+	cout << "String: " + s << endl;
+	for (unsigned int k = 0; k < s.length(); k++)
 	{
 		char *ch = new char[1];
 		*ch = s.at(k);
-        stack->push(ch); // take the address of the variable ch
+		stack->push(ch); // take the address of the variable ch
 	}
 	/*cout << "the stack has:" << endl;*/
 	/*stack->print();*/
 
-    Node * node;
-    string reversed = "";
-    while (!stack->isEmpty()) {
-        node  = stack->pop();
-        reversed = reversed + node->toString();
-    }
-    cout << "Reversed String: " + reversed << endl;
+	Node * node;
+	string reversed = "";
+	while (!stack->isEmpty())
+	{
+		node  = stack->pop();
+		reversed = reversed + node->toString();
+	}
+	cout << "Reversed String: " + reversed << endl;
 } // main()
 

--- a/C-examples/C++/stringTokenizer/StringTokenizer.cc
+++ b/C-examples/C++/stringTokenizer/StringTokenizer.cc
@@ -8,7 +8,7 @@ StringTokenizer::StringTokenizer(string inString, string delimiter)
 	this->delimiter = delimiter;
 
 	// create a C-style string from inString
-	// A C-style string is an array of char's followed by a 
+	// A C-style string is an array of char's followed by a
 	// null character (which has code 0)
 	s = new char[inputStr.length() + 1];
 	inputStr.copy(s,string::npos); //npos denotes end of string

--- a/C-examples/bitwise-operators/bitmanip.c
+++ b/C-examples/bitwise-operators/bitmanip.c
@@ -10,37 +10,37 @@ void printResult(int, unsigned int, unsigned int);
 
 int main(int argc, char *argv[])
 {
-    if(argc != 3)
-    {
-        printf("Usage: %s <number> <bit index>\n", argv[0]);
-        return 0;
-    }
+	if(argc != 3)
+	{
+		printf("Usage: %s <number> <bit index>\n", argv[0]);
+		return 0;
+	}
 
-    unsigned int number = (unsigned int) atoi(argv[1]);
-    int i = atoi(argv[2]);
+	unsigned int number = (unsigned int) atoi(argv[1]);
+	int i = atoi(argv[2]);
 
-    printf("Number: %d (0x%x)\n", number, number);
-    printf("Modifying bit: %d\n", i);
+	printf("Number: %d (0x%x)\n", number, number);
+	printf("Modifying bit: %d\n", i);
 
-    // Check if bit i is set
-    unsigned int result = isBitISet(number, i);
-    printResult(i, number, result);
+	// Check if bit i is set
+	unsigned int result = isBitISet(number, i);
+	printResult(i, number, result);
 
-    // Set it
-    number = setBit(number, i);
+	// Set it
+	number = setBit(number, i);
 
-    // Make sure it was set
-    result = isBitISet(number, i);
-    printResult(i, number, result);
+	// Make sure it was set
+	result = isBitISet(number, i);
+	printResult(i, number, result);
 
-    // Clear bit
-    number = clearBit(number, i);
+	// Clear bit
+	number = clearBit(number, i);
 
-    // Make sure it was cleared
-    result = isBitISet(number, i);
-    printResult(i, number, result);
+	// Make sure it was cleared
+	result = isBitISet(number, i);
+	printResult(i, number, result);
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -53,14 +53,14 @@ int main(int argc, char *argv[])
  */
 void printResult(int i, unsigned int num, unsigned int isSet)
 {
-    if(isSet == 0)
-    {
-        printf("Bit %d is NOT set (0x%x)\n", i, num);
-    }
-    else
-    {
-        printf("Bit %d is set (0x%x)\n", i, num);
-    }
+	if(isSet == 0)
+	{
+		printf("Bit %d is NOT set (0x%x)\n", i, num);
+	}
+	else
+	{
+		printf("Bit %d is set (0x%x)\n", i, num);
+	}
 }
 
 /**
@@ -70,8 +70,8 @@ void printResult(int i, unsigned int num, unsigned int isSet)
  */
 unsigned int isBitISet(unsigned int ch, int i)
 {
-    unsigned int mask = 1U << i;
-    return mask & ch;
+	unsigned int mask = 1U << i;
+	return mask & ch;
 }
 
 /**
@@ -81,8 +81,8 @@ unsigned int isBitISet(unsigned int ch, int i)
  */
 unsigned int setBit(unsigned int ch, int i)
 {
-    unsigned int mask = 1U << i;
-    return mask | ch;
+	unsigned int mask = 1U << i;
+	return mask | ch;
 }
 
 /**
@@ -93,5 +93,5 @@ unsigned int setBit(unsigned int ch, int i)
  */
 unsigned int clearBit(unsigned int ch, int i)
 {
-    return 0;
+	return 0;
 }

--- a/C-examples/bitwise-operators/getbits.c
+++ b/C-examples/bitwise-operators/getbits.c
@@ -9,18 +9,21 @@ int main(int argc, char *argv[])
 {
 	unsigned int x, n, p, result;
 
-	if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr, "Usage: %s <x> <position> <field-width>\n", argv[0]);
 		return 1;
-	} else {
+	}
+	else
+	{
 		x = (unsigned int) atoi(argv[1]);
 		p = (unsigned int) atoi(argv[2]);
 		n = (unsigned int) atoi(argv[3]);
 	}
 
-    result = getbits(x, p, n);
-    printf("x = %d 0x%X result: %d 0x%X\n", x, x, result, result);
-    return 0;
+	result = getbits(x, p, n);
+	printf("x = %d 0x%X result: %d 0x%X\n", x, x, result, result);
+	return 0;
 }
 
 /*
@@ -38,7 +41,7 @@ int main(int argc, char *argv[])
  */
 unsigned int getbits(unsigned int x, unsigned int p, unsigned int n)
 {
-    return (x >> (p+1-n)) & ~(~0U << n);
+	return (x >> (p+1-n)) & ~(~0U << n);
 }
 
 /*

--- a/C-examples/bitwise-operators/pack.c
+++ b/C-examples/bitwise-operators/pack.c
@@ -8,35 +8,36 @@ void unpackWithMask(unsigned int val);
 
 unsigned int isBitISet(unsigned int ch, int i)
 {
-    unsigned int mask = 1U << i;
-    return mask & ch;
+	unsigned int mask = 1U << i;
+	return mask & ch;
 }
 
 void visualize(unsigned int x)
 {
-    int i;
-    for(;;) /* modify this!! */
-    {
-        if(1) /* modify this!! */
-            printf("1");
-        else
-            printf("0");
-    }
-    printf("\n");
+	int i;
+	for(;;) /* modify this!! */
+	{
+		if(1) /* modify this!! */
+			printf("1");
+		else
+			printf("0");
+	}
+	printf("\n");
 }
 
-int main(void){
-    unsigned char red = 255;   // 1111 1111
-    unsigned char green = 135; // 1000 0111
-    unsigned char blue = 111;  // 0110 1111
-    unsigned char alpha = 100; // 0110 0100
+int main(void)
+{
+	unsigned char red = 255;   // 1111 1111
+	unsigned char green = 135; // 1000 0111
+	unsigned char blue = 111;  // 0110 1111
+	unsigned char alpha = 100; // 0110 0100
 
-    unsigned int result = 0;// 1111 1111 | 1000 0111 | 0110 1111 | 0110 0100
-    result=pack(red, green, blue, alpha);
-    unpackWithShift(result);
-    unpackWithMask(result);
+	unsigned int result = 0;// 1111 1111 | 1000 0111 | 0110 1111 | 0110 0100
+	result=pack(red, green, blue, alpha);
+	unpackWithShift(result);
+	unpackWithMask(result);
 
-    return 0;
+	return 0;
 }
 
 unsigned int pack(unsigned char red,
@@ -44,21 +45,21 @@ unsigned int pack(unsigned char red,
                   unsigned char blue,
                   unsigned char alpha)
 {
-    printf("Pack red=%u, green=%u, blue=%u, alpha=%u\n",red,green,blue,alpha);
-    unsigned int result = UINT_MAX;
-    printf("result %u\n",result);
-    visualize(result);
+	printf("Pack red=%u, green=%u, blue=%u, alpha=%u\n",red,green,blue,alpha);
+	unsigned int result = UINT_MAX;
+	printf("result %u\n",result);
+	visualize(result);
 
-    /* result = result<<24;  */
+	/* result = result<<24;  */
 
-    // pack it here
+	// pack it here
 
-    return result;
+	return result;
 }
 
 void unpackWithShift(unsigned int val)
 {
-    printf("Unpacking bits by shifting\n");
+	printf("Unpacking bits by shifting\n");
 
 
 
@@ -70,7 +71,7 @@ void unpackWithShift(unsigned int val)
 
 void unpackWithMask(unsigned int val)
 {
-    printf("Unpacking bits by masking\n");
+	printf("Unpacking bits by masking\n");
 
 
 

--- a/C-examples/bitwise-operators/shift-overflow.c
+++ b/C-examples/bitwise-operators/shift-overflow.c
@@ -4,13 +4,13 @@
 
 int main(int argc, char *argv[])
 {
-    unsigned char maxc = 255;
+	unsigned char maxc = 255;
 
-    unsigned char c = maxc << 1;
-    printf("%u << %u : unsigned char c = %u\n", maxc, 1, c);
+	unsigned char c = maxc << 1;
+	printf("%u << %u : unsigned char c = %u\n", maxc, 1, c);
 
-    unsigned int i = maxc << 1;
-    printf("%u << %u : unsigned int i = %u\n", maxc, 1, i);
+	unsigned int i = maxc << 1;
+	printf("%u << %u : unsigned int i = %u\n", maxc, 1, i);
 
-    return 0;
+	return 0;
 }

--- a/C-examples/c-preprocessor/ex1.c
+++ b/C-examples/c-preprocessor/ex1.c
@@ -18,23 +18,25 @@
 int main(int argc, char *argv[])
 {
 	char c;
-   	long nc, nw, nl;	
+	long nc, nw, nl;
 	int state;
 
 	state = OUT;
 	nl = nw = nc = 0;
-	while ((c = getchar()) != EOF ) {
+	while ((c = getchar()) != EOF )
+	{
 #ifdef DEBUG
 		printf("c=%c\n",c);
 #endif
 #if DEBUG==1
-               printf("level 1");
+		printf("level 1");
 #endif
 		nc++;
 #ifdef DEBUG
 		printf("nc=%ld\n",nc);
 #endif
-		if (c == '\n') {
+		if (c == '\n')
+		{
 			nl++;
 #ifdef DEBUG
 			printf("nl=%ld\n",nl);
@@ -42,11 +44,12 @@ int main(int argc, char *argv[])
 		}
 		if (c == ' ' || c == '\n' || c == '\t')
 			state = OUT;
-		else if (state == OUT) {
-				state = IN;
-				nw++;
+		else if (state == OUT)
+		{
+			state = IN;
+			nw++;
 #ifdef DEBUG
-				printf("nw=%ld\n",nw);
+			printf("nw=%ld\n",nw);
 #endif
 		}
 	}

--- a/C-examples/c-preprocessor/ex2.c
+++ b/C-examples/c-preprocessor/ex2.c
@@ -9,14 +9,14 @@
  */
 int main(int argc, char *argv[])
 {
-	#ifdef _WIN32
-		printf("Welcome to MS Windows ( I rule!).\n");
-	#elif __linux__
-		printf("I am the Happy Penguin!\n");
-	#elif __APPLE__&&__MACH__
-		printf("Welcome to I am cool!\n");
-	#else
-		printf("Uh! who am i?\n");
-	#endif
+#ifdef _WIN32
+	printf("Welcome to MS Windows ( I rule!).\n");
+#elif __linux__
+	printf("I am the Happy Penguin!\n");
+#elif __APPLE__&&__MACH__
+	printf("Welcome to I am cool!\n");
+#else
+	printf("Uh! who am i?\n");
+#endif
 	exit(0);
 }

--- a/C-examples/c-preprocessor/macro.c
+++ b/C-examples/c-preprocessor/macro.c
@@ -7,13 +7,13 @@
 
 int main(int argc, char *argv[])
 {
-    double dSmall = 2, dBig = 100;
-    int iSmall = 2, iBig = 100;
-    char cSmall = 'a', cBig = 'z';
+	double dSmall = 2, dBig = 100;
+	int iSmall = 2, iBig = 100;
+	char cSmall = 'a', cBig = 'z';
 
-    printf("max(%.2f,%.2f) = %.2f\n", dSmall, dBig, max(dSmall, dBig));
-    printf("max(%d,%d) = %d\n", iSmall, iBig, max(iSmall, iBig));
-    printf("max(%c,%c) = %c\n", cSmall, cBig, max(cSmall, cBig));
+	printf("max(%.2f,%.2f) = %.2f\n", dSmall, dBig, max(dSmall, dBig));
+	printf("max(%d,%d) = %d\n", iSmall, iBig, max(iSmall, iBig));
+	printf("max(%c,%c) = %c\n", cSmall, cBig, max(cSmall, cBig));
 
-    return 0;
+	return 0;
 }

--- a/C-examples/exception/Exception.c
+++ b/C-examples/exception/Exception.c
@@ -64,7 +64,7 @@ void *push_env()
  * pop_env() */
 void *pop_env()
 {
-	if (env_index == 0) 
+	if (env_index == 0)
 		fatal("Exception: pop_env(): stack underflow");
 	return (void *)env_stack[--env_index];
 }/*pop_env()*/
@@ -75,7 +75,7 @@ int main(int argc, char **args)
 {
 	Exception *e1=NewException();
 	Exception *e2=NewException();
-	
+
 	try(e1)
 	{
 		try(e2)

--- a/C-examples/file-io/checkpoint/Job.c
+++ b/C-examples/file-io/checkpoint/Job.c
@@ -6,7 +6,7 @@ JobPtr createJob(int jobid, char *info)
 	JobPtr newJob = (JobPtr) malloc (sizeof(Job));
 	newJob->jobid = jobid;
 	newJob->info = (char *) malloc(sizeof(char)*(strlen(info)+1));
-	strcpy(newJob->info, info); 
+	strcpy(newJob->info, info);
 	newJob->infoSize = strlen(info)+1;
 	return newJob;
 }
@@ -34,7 +34,7 @@ int getJobSize(JobPtr job)
 
 /*
 Function name: checkpointJob
-Description: WARNING! Writes a checkpoint for a Job structure to  an output 
+Description: WARNING! Writes a checkpoint for a Job structure to  an output
 			stream without any checks. The idea is that some higher level
 			class (like List or Node) would call this function after having
 			checked for the file output stream to be set properly. We also

--- a/C-examples/file-io/checkpoint/List.c
+++ b/C-examples/file-io/checkpoint/List.c
@@ -5,9 +5,9 @@
 
 /*
 
-	list.c 
+	list.c
 		Contains functions to manipulate a doubly-linked list.
- 
+
 */
 
 
@@ -51,7 +51,9 @@ void addAtFront(ListPtr list, NodePtr node)
 	{
 		list->head = node;
 		list->tail = node;
-	} else {
+	}
+	else
+	{
 		list->head->prev = node;
 		list->head = node;
 	}
@@ -99,20 +101,21 @@ static void print(NodePtr node)
 {
 	char *output;
 
-	while (node) {
+	while (node)
+	{
 		output = toString(node->data);
 		printf("%s\n",output);
 		free(output);
 		node = node->next;
 	}
-    printf("NULL\n");
+	printf("NULL\n");
 }
- 
+
 
 void freeList(ListPtr L)
 {
 }
-		
+
 
 /**
 	Checkpoint the whole list to disk so we can restore it later.
@@ -136,7 +139,8 @@ Boolean checkpointList(ListPtr list, char *saveFile)
 	if (strlen(saveFile) == 0) return FALSE;
 
 	fout = fopen(saveFile, "w");
-	if (!fout) {
+	if (!fout)
+	{
 		sprintf(errmsg, "checkpointList: %s",saveFile);
 		perror(errmsg);
 		return FALSE;
@@ -145,7 +149,8 @@ Boolean checkpointList(ListPtr list, char *saveFile)
 	fwrite(&(list->size), sizeof(int), 1, fout);
 
 	node = list->tail;
-	while (node) {
+	while (node)
+	{
 		checkpointNode(node, fout);
 		node = node->prev;
 	}
@@ -175,7 +180,8 @@ ListPtr restoreList(char *saveFile)
 	if (saveFile == NULL) return NULL;
 	if (strlen(saveFile) == 0) return NULL;
 	fin = fopen(saveFile, "r");
-	if (!fin) {
+	if (!fin)
+	{
 		sprintf(errmsg, "restoreList: %s",saveFile);
 		perror(errmsg);
 		return NULL;
@@ -186,7 +192,8 @@ ListPtr restoreList(char *saveFile)
 	printf("restore: list size = %d\n", size);
 	list = createList();
 
-	while (size > 0) {
+	while (size > 0)
+	{
 		node = restoreNode(fin);
 		addAtFront(list, node);
 		size--;

--- a/C-examples/file-io/checkpoint/Node.c
+++ b/C-examples/file-io/checkpoint/Node.c
@@ -27,7 +27,7 @@ int getDataSize(NodePtr node)
 
 /*
 Function name: checkpointNode
-Description: WARNING! Writes a checkpoint for a Node structure to  an output 
+Description: WARNING! Writes a checkpoint for a Node structure to  an output
 			stream without any checks. The idea is that some higher level
 			class (like List) would call this function after having
 			checked for the file output stream to be set properly. We also
@@ -50,9 +50,9 @@ void checkpointNode(NodePtr node, FILE *fout)
 /*
 Function name: restoreNode
 Description: WARNING! Reads from a binary input stream to rsrtore a Node
- 			structure. The idea is that some higher level class (like List) 
-			would call this function after having checked for the file input 
-			stream to be set properly. We don't check for EOF or other errors 
+ 			structure. The idea is that some higher level class (like List)
+			would call this function after having checked for the file input
+			stream to be set properly. We don't check for EOF or other errors
 			at this level.
 
 	Input: fin ---> binary input stream

--- a/C-examples/file-io/checkpoint/RestoreList.c
+++ b/C-examples/file-io/checkpoint/RestoreList.c
@@ -10,18 +10,20 @@
 
 
 int main(int argc, char **argv)
-{	
+{
 	ListPtr list;
 	char *saveFile;
 
-	if (argc != 2) {
-			fprintf(stderr, "Usage: %s <checkpoint file> \n",argv[0]);
-			exit(1);
+	if (argc != 2)
+	{
+		fprintf(stderr, "Usage: %s <checkpoint file> \n",argv[0]);
+		exit(1);
 	}
 	saveFile =argv[1];
 
 	list = restoreList(saveFile);
-	if (list) {
+	if (list)
+	{
 		printList(list);
 	}
 	exit(0);

--- a/C-examples/file-io/checkpoint/SaveList.c
+++ b/C-examples/file-io/checkpoint/SaveList.c
@@ -9,7 +9,7 @@
 
 
 int main(int argc, char **argv)
-{	
+{
 	int i;
 	int n;
 	NodePtr node;
@@ -17,13 +17,15 @@ int main(int argc, char **argv)
 	ListPtr list;
 	char *saveFile;
 
-	if (argc < 2) {
+	if (argc < 2)
+	{
 		fprintf(stderr, "Usage: %s <list size> [<checkpoint file>] \n",argv[0]);
 		exit(1);
 	}
 	n = atoi(argv[1]);
 	saveFile = NULL;
-	if (argc == 3) {
+	if (argc == 3)
+	{
 		saveFile = argv[2];
 	}
 
@@ -38,7 +40,8 @@ int main(int argc, char **argv)
 	if (!saveFile) printList(list);
 	printList(list);
 
-	if (saveFile) {
+	if (saveFile)
+	{
 		printf("checkpointing to file %s\n", saveFile);
 		checkpointList(list, saveFile);
 	}

--- a/C-examples/file-io/disk_search/ExternalSearch.c
+++ b/C-examples/file-io/disk_search/ExternalSearch.c
@@ -18,22 +18,29 @@ RecordPtr extBinarySearch(FILE *dataFile, unsigned long int key)
 	high = numRecords(dataFile);
 
 	record = (RecordPtr) malloc(sizeof(Record));
-	while (low <= high) {
+	while (low <= high)
+	{
 		mid = (low+high)/2;
 		pos = mid * sizeof(Record); /* calculate byte offset in the file */
 		fseek(dataFile, pos, SEEK_SET);
 		fread(record, sizeof(Record), 1, dataFile);
-		if (DEBUG >= 2) {
+		if (DEBUG >= 2)
+		{
 			buffer = toString(record);
 			fprintf(stderr, "low = %ld mid = %ld high = %ld\n", low, mid, high);
 			fprintf(stderr, "====>record: %s", buffer);
 			free(buffer);
 		}
-		if (record->key == key) {
+		if (record->key == key)
+		{
 			return record;
-		} else if (record->key < key) {
+		}
+		else if (record->key < key)
+		{
 			low = mid + 1;
-		} else { /* record->key > key */
+		}
+		else     /* record->key > key */
+		{
 			high = mid - 1;
 		}
 	}
@@ -54,11 +61,13 @@ RecordPtr extLinearSearch(FILE *dataFile, unsigned long int key)
 	count = numRecords(dataFile);
 
 	record = (RecordPtr) malloc(sizeof(Record));
-	for (i = 0; i < count; i++) {
+	for (i = 0; i < count; i++)
+	{
 		pos = i * sizeof(Record); /* calculate byte offset in the file */
 		fseek(dataFile, pos, SEEK_SET);
 		fread(record, sizeof(Record), 1, dataFile);
-		if (record->key == key) {
+		if (record->key == key)
+		{
 			return record;
 		}
 	}
@@ -77,7 +86,8 @@ static long int numRecords(FILE *dataFile)
 	count = ftell(dataFile);
 	/* set high to number of records in the file */
 	count = count/sizeof(Record);
-	if (DEBUG >= 2) {
+	if (DEBUG >= 2)
+	{
 		fprintf(stderr, "data file has %ld records\n", count);
 	}
 	return count;

--- a/C-examples/file-io/disk_search/Record.c
+++ b/C-examples/file-io/disk_search/Record.c
@@ -8,7 +8,7 @@ char *toString(RecordPtr record)
 	char *buffer;
 
 	buffer = (char *) malloc(sizeof(char) * MAXLEN);
-	sprintf(buffer, "key=%ld values=[%lf, %lf, %lf]\n", 
-			record->key, record->value1, record->value2, record->value3);
+	sprintf(buffer, "key=%ld values=[%lf, %lf, %lf]\n",
+	        record->key, record->value1, record->value2, record->value3);
 	return buffer;
 }

--- a/C-examples/file-io/disk_search/SearchTest.c
+++ b/C-examples/file-io/disk_search/SearchTest.c
@@ -15,9 +15,9 @@ double getMilliseconds();
 /**
  * @brief See function name
  *
- * @param dataFile - The file to search 
+ * @param dataFile - The file to search
  * @param n - The number of searches to conduct
- * @param searchType - The type of search BINARY or LINEAR 
+ * @param searchType - The type of search BINARY or LINEAR
  */
 void conduct_random_searches(FILE *dataFile, long int n, int searchType)
 {
@@ -26,28 +26,35 @@ void conduct_random_searches(FILE *dataFile, long int n, int searchType)
 	Record *record;
 	char *buffer;
 
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		key = (unsigned long int) random() % MAX_KEY;
-		if (DEBUG >= 1) {
-				printf("\nSearching for key = %ld\n\n", key);
+		if (DEBUG >= 1)
+		{
+			printf("\nSearching for key = %ld\n\n", key);
 		}
-		switch (searchType) {
-			case BINARY: 
-				record = extBinarySearch(dataFile, key);
-				break;
-			case LINEAR:
-				record = extLinearSearch(dataFile, key);
-				break;
+		switch (searchType)
+		{
+		case BINARY:
+			record = extBinarySearch(dataFile, key);
+			break;
+		case LINEAR:
+			record = extLinearSearch(dataFile, key);
+			break;
 		}
 
-		if (DEBUG >= 1) {
-			if (record) {
+		if (DEBUG >= 1)
+		{
+			if (record)
+			{
 				buffer = toString(record);
 				printf("%s\n", buffer);
 				printf("found: record with key %ld\n", key);
 				free(record);
 				free(buffer);
-			} else {
+			}
+			else
+			{
 				printf("not found: record with key %ld\n", key);
 			}
 		}
@@ -55,7 +62,8 @@ void conduct_random_searches(FILE *dataFile, long int n, int searchType)
 }
 
 
-void print_usage(int argc, char **argv) {
+void print_usage(int argc, char **argv)
+{
 	fprintf(stderr, "Usage: %s <data file name> <number of searches> [binary|linear]\n", program);
 	exit(1);
 }
@@ -72,22 +80,26 @@ int main (int argc, char **argv)
 
 	program = argv[0];
 
-	if (argc < 3 || argc > 5) {
+	if (argc < 3 || argc > 5)
+	{
 		print_usage(argc, argv);
 	}
 	n = atoi(argv[2]);
 	dataFile = fopen(argv[1], "r");
-	if (!dataFile) {
+	if (!dataFile)
+	{
 		perror(program);
 		exit(1);
 	}
 	searchType = BINARY;
-	if (argc == 4) {
-		if (argv[3][0] == 'b') 
+	if (argc == 4)
+	{
+		if (argv[3][0] == 'b')
 			searchType = BINARY;
 		else if (argv[3][0] == 'l')
 			searchType = LINEAR;
-		else {
+		else
+		{
 			fprintf(stderr, "Usage: choose correct search type!\n");
 			print_usage(argc, argv);
 		}
@@ -96,8 +108,9 @@ int main (int argc, char **argv)
 	fseek(dataFile, 0, SEEK_END);
 	count = ftell(dataFile);
 	count = count/sizeof(Record);
-	if (DEBUG >= 1) {
-		   fprintf(stderr, "data file has %ld records\n", count);
+	if (DEBUG >= 1)
+	{
+		fprintf(stderr, "data file has %ld records\n", count);
 	}
 
 	startTime = getMilliseconds();

--- a/C-examples/file-io/disk_search/gendata.c
+++ b/C-examples/file-io/disk_search/gendata.c
@@ -3,7 +3,8 @@
 #include <stdlib.h>
 #include <time.h>
 
-struct record {
+struct record
+{
 	int key;
 	double value1;
 	double value2;
@@ -19,7 +20,8 @@ void generate_file(int n, unsigned int seed, FILE *fout)
 
 	next = (struct record *) malloc(sizeof(struct record));
 
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		next->key =  i*2;
 		next->value1 = rand()/((double)MAX_KEY);
 		next->value2 = rand()/((double)MAX_KEY);
@@ -34,19 +36,22 @@ int main(int argc, char **argv)
 	unsigned int seed;
 	FILE *fout;
 
-	if (argc < 2) {
+	if (argc < 2)
+	{
 		fprintf(stderr, "Usage: %s <n> [<seed>]\n", argv[0]);
 		exit(1);
 	}
 
 	n = atoi(argv[1]);
-	if (argc == 3) {
+	if (argc == 3)
+	{
 		seed = atoi(argv[1]);
-	} 
+	}
 
 
 	fout = fopen("data.bin", "w");
-	if (!fout) {
+	if (!fout)
+	{
 		perror("");
 	}
 

--- a/C-examples/file-io/disk_search/timing.c
+++ b/C-examples/file-io/disk_search/timing.c
@@ -11,24 +11,24 @@
 clock_t times(struct tms *buffer);
 
 times() fills the structure pointed to by buffer with
-time-accounting information.  The structure defined in 
+time-accounting information.  The structure defined in
 <sys/times.h> is as follows:
 
 struct tms {
-    clock_t tms_utime;       user time 
-    clock_t tms_stime;       system time 
-    clock_t tms_cutime;      user time, children 
-    clock_t tms_cstime;      system time, children 
+    clock_t tms_utime;       user time
+    clock_t tms_stime;       system time
+    clock_t tms_cutime;      user time, children
+    clock_t tms_cstime;      system time, children
 
 The time is given in units of 1/CLK_TCK seconds where the
 value of CLK_TCK can be determined using the sysconf() function
 with the agrgument _SC_CLK_TCK.
 ---------------------------------------------------------------------------
 */
-								  
+
 
 float report_cpu_time()
-{ 
+{
 	struct tms buffer;
 	float cputime;
 
@@ -39,7 +39,7 @@ float report_cpu_time()
 
 
 float report_sys_time()
-{ 
+{
 	struct tms buffer;
 	float systime;
 
@@ -50,8 +50,8 @@ float report_sys_time()
 
 double getMilliseconds()
 {
-    struct timeval now;
-    gettimeofday(&now, (struct timezone *)0);
-    return (double) now.tv_sec*1000.0 + now.tv_usec/1000.0;
+	struct timeval now;
+	gettimeofday(&now, (struct timezone *)0);
+	return (double) now.tv_sec*1000.0 + now.tv_usec/1000.0;
 }
 

--- a/C-examples/file-io/filesize.c
+++ b/C-examples/file-io/filesize.c
@@ -10,13 +10,15 @@ int main(int argc, char **argv)
 	long int size;
 	FILE *fin;
 
-	if (argc !=2 ) {
+	if (argc !=2 )
+	{
 		fprintf(stderr, "Usage: %s <filename>\n", argv[0]);
 		exit(1);
 	}
 
 	fin = fopen(argv[1], "r");
-	if (!fin) {
+	if (!fin)
+	{
 		perror("filesize:");
 		exit(-1);
 	}

--- a/C-examples/file-io/generate_binary.c
+++ b/C-examples/file-io/generate_binary.c
@@ -3,7 +3,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-struct record {
+struct record
+{
 	int key;
 	double value1;
 	double value2;
@@ -20,7 +21,8 @@ void generate_file(int n, unsigned int seed, FILE *fout)
 	next = (struct record *) malloc(sizeof(struct record));
 
 	srand(seed); /* set starting seed for rand num. generator */
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		next->key = rand() % MAX_KEY;
 		next->value1 = rand()/((double)MAX_KEY);
 		next->value2 = rand()/((double)MAX_KEY);
@@ -36,19 +38,22 @@ int main(int argc, char **argv)
 	unsigned int seed;
 	FILE *fout;
 
-	if (argc < 2) {
+	if (argc < 2)
+	{
 		fprintf(stderr, "Usage: %s <n> [<seed>]\n", argv[0]);
 		exit(1);
 	}
 
 	n = atoi(argv[1]);
-	if (argc == 3) {
+	if (argc == 3)
+	{
 		seed = atoi(argv[1]);
-	} 
+	}
 
 
 	fout = fopen("data.bin", "w");
-	if (!fout) {
+	if (!fout)
+	{
 		perror("");
 	}
 

--- a/C-examples/file-io/generate_text.c
+++ b/C-examples/file-io/generate_text.c
@@ -4,7 +4,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-struct record {
+struct record
+{
 	int key;
 	double value1;
 	double value2;
@@ -21,13 +22,14 @@ void generate_file(int n, unsigned int seed, FILE *fout)
 	next = (struct record *) malloc(sizeof(struct record));
 
 	srand(seed); /* set starting seed for random num. generator */
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		next->key = rand() % MAX_KEY;
 		next->value1 = rand()/((double)MAX_KEY);
 		next->value2 = rand()/((double)MAX_KEY);
 		next->value3 = rand()/((double)MAX_KEY);
-		fprintf(fout, "%d %lf %lf %lf\n", next->key, 
-				next->value1, next->value2, next->value3);
+		fprintf(fout, "%d %lf %lf %lf\n", next->key,
+		        next->value1, next->value2, next->value3);
 	}
 	free(next);
 }
@@ -38,19 +40,22 @@ int main(int argc, char **argv)
 	unsigned int seed;
 	FILE *fout;
 
-	if (argc < 2) {
+	if (argc < 2)
+	{
 		fprintf(stderr, "Usage: %s <n> [<seed>]\n", argv[0]);
 		exit(1);
 	}
 
 	n = atoi(argv[1]);
-	if (argc == 3) {
+	if (argc == 3)
+	{
 		seed = atoi(argv[1]);
-	} 
+	}
 
 
 	fout = fopen("data.txt", "w");
-	if (!fout) {
+	if (!fout)
+	{
 		perror("gentxt");
 	}
 

--- a/C-examples/file-io/readfile.c
+++ b/C-examples/file-io/readfile.c
@@ -6,26 +6,26 @@
 
 int main(int argc, char **argv)
 {
-    if(argc != 2)
-    {
-        printf("Usage: %s <filepath>\n", argv[0]);
-        exit(1);
-    }
+	if(argc != 2)
+	{
+		printf("Usage: %s <filepath>\n", argv[0]);
+		exit(1);
+	}
 
-    FILE *fin = fopen(argv[1], "r");
-    if(!fin)
-    {
-        perror(argv[1]);
-        exit(errno);
-    }
+	FILE *fin = fopen(argv[1], "r");
+	if(!fin)
+	{
+		perror(argv[1]);
+		exit(errno);
+	}
 
-    char buffer[MAX_LINE_LENGTH];
-   
-    while(fgets(buffer, sizeof(buffer), fin))
-    {
-        printf("%s", buffer);
-    }
+	char buffer[MAX_LINE_LENGTH];
 
-    fclose(fin);
-    return 0;
+	while(fgets(buffer, sizeof(buffer), fin))
+	{
+		printf("%s", buffer);
+	}
+
+	fclose(fin);
+	return 0;
 }

--- a/C-examples/function-pointers/fun-with-fns.c
+++ b/C-examples/function-pointers/fun-with-fns.c
@@ -3,22 +3,26 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int foobar0(int x) {
+int foobar0(int x)
+{
 	printf("I have been invoked!!!! x=%d\n",x);
 	return x;
 }
 
-int foobar1(int x) {
+int foobar1(int x)
+{
 	printf("I have been invoked!!!! x=%d\n",x*2);
 	return x;
 }
 
-int foobar2(int x) {
+int foobar2(int x)
+{
 	printf("I have been invoked!!!! x=%d\n",x*3);
 	return x;
 }
 
-void fun(int (*fn)(int)) {
+void fun(int (*fn)(int))
+{
 	int result;
 
 	result = (*fn) (5);
@@ -36,7 +40,8 @@ int main(int argc, char **argv)
 	names[1] = foobar1;
 	names[2] = foobar2;
 
-	if (argc != 3) {
+	if (argc != 3)
+	{
 		fprintf(stderr,"Usage %s: <count> <seed> \n",argv[0]);
 		exit(1);
 	}
@@ -51,7 +56,8 @@ int main(int argc, char **argv)
 
 
 	srandom(seed);
-	for (i=0; i<count; i++) {
+	for (i=0; i<count; i++)
+	{
 		fun(names[random()%3]);
 	}
 

--- a/C-examples/function-pointers/myfunc.c
+++ b/C-examples/function-pointers/myfunc.c
@@ -4,127 +4,151 @@
 static const int MAX = 10;
 
 
-void usage(char** argv){
-    fprintf(stderr,"%s <a = ascending | b = descending>\n",argv[0]);
-    exit(0);
+void usage(char** argv)
+{
+	fprintf(stderr,"%s <a = ascending | b = descending>\n",argv[0]);
+	exit(0);
 }
 
-void ascend(void *a, void *b){
-   int *first = (int*) a;
-   int *second = (int*) b;
-   int tmp =0;
-   if(*first > *second){
-       tmp = *first;
-       *first = *second;
-       *second = tmp;
-   }
-
-}
-
-void descend(void *a, void *b){
-   int *first = (int*) a;
-   int *second = (int*) b;
-   int tmp =0;
-   if(*first < *second){
-       tmp = *first;
-       *first = *second;
-       *second = tmp;
-   }
-}
-
-void charAscend(void *a, void *b){
-   char *first = (char*) a;
-   char *second = (char*) b;
-   char tmp =0;
-   if(*first > *second){
-       tmp = *first;
-       *first = *second;
-       *second = tmp;
-   }
+void ascend(void *a, void *b)
+{
+	int *first = (int*) a;
+	int *second = (int*) b;
+	int tmp =0;
+	if(*first > *second)
+	{
+		tmp = *first;
+		*first = *second;
+		*second = tmp;
+	}
 
 }
 
-void charDescend(void *a, void *b){
-   char *first = (char*) a;
-   char *second = (char*) b;
-   char tmp =0;
-   if(*first < *second){
-       tmp = *first;
-       *first = *second;
-       *second = tmp;
-   }
+void descend(void *a, void *b)
+{
+	int *first = (int*) a;
+	int *second = (int*) b;
+	int tmp =0;
+	if(*first < *second)
+	{
+		tmp = *first;
+		*first = *second;
+		*second = tmp;
+	}
+}
+
+void charAscend(void *a, void *b)
+{
+	char *first = (char*) a;
+	char *second = (char*) b;
+	char tmp =0;
+	if(*first > *second)
+	{
+		tmp = *first;
+		*first = *second;
+		*second = tmp;
+	}
+
+}
+
+void charDescend(void *a, void *b)
+{
+	char *first = (char*) a;
+	char *second = (char*) b;
+	char tmp =0;
+	if(*first < *second)
+	{
+		tmp = *first;
+		*first = *second;
+		*second = tmp;
+	}
 }
 
 void sort(void *base ,size_t size, int len, void (*swp)(void*, void*))
 {
-    int i, j;
-    for(i = 0; i< len ;i++){
-        for(j = i + 1; j<len ; j++){
-            swp(base + (i * size) , base + (j*size));
+	int i, j;
+	for(i = 0; i< len ; i++)
+	{
+		for(j = i + 1; j<len ; j++)
+		{
+			swp(base + (i * size) , base + (j*size));
 
-        }
-    }
+		}
+	}
 
 }
 
 int main(int argc, char** argv)
 {
 
-    if(argc != 2) {
-        usage(argv);
-    }
-    
-    int foo = 0;
+	if(argc != 2)
+	{
+		usage(argv);
+	}
 
-    if(argv[1][0] == 'a'){
-        printf("sorting ascending\n");
-        foo = 1;
-    }else if(argv[1][0] == 'b'){
-        printf("sorting descending\n");
-        foo = 2;
-    }else{
-        usage(argv);
-    }
+	int foo = 0;
 
-
-
-    int *a = (int*)malloc(sizeof(int)*MAX);
-    char *b = (char*)malloc(sizeof(char)*MAX);
-    int i;
-    srandom(0);
-    for(i=0;i<MAX;i++){
-        a[i]= random() % 20;
-    }
-    for(i=0;i<MAX;i++){
-        b[i]= 65 + (random() % 26); 
-    }
-    printf("Before sort\n");
-
-    for(i=0;i<MAX;i++){
-       printf("b[%d]= %c\n",i,b[i]);
-    }
-
-    if(foo ==1 ){
-        sort(a,sizeof(int), MAX,ascend); 
-        sort(b,sizeof(char),MAX,charAscend);
-    }else if(foo ==2){
-        sort(a,sizeof(int), MAX,descend);
-        sort(b,sizeof(char),MAX,charDescend);
-    }
+	if(argv[1][0] == 'a')
+	{
+		printf("sorting ascending\n");
+		foo = 1;
+	}
+	else if(argv[1][0] == 'b')
+	{
+		printf("sorting descending\n");
+		foo = 2;
+	}
+	else
+	{
+		usage(argv);
+	}
 
 
-    printf("----------------------\n");
-    printf("After sort\n");
 
-    for(i=0;i<MAX;i++){
-       printf("b[%d]= %c\n",i,b[i]);
-    }
+	int *a = (int*)malloc(sizeof(int)*MAX);
+	char *b = (char*)malloc(sizeof(char)*MAX);
+	int i;
+	srandom(0);
+	for(i=0; i<MAX; i++)
+	{
+		a[i]= random() % 20;
+	}
+	for(i=0; i<MAX; i++)
+	{
+		b[i]= 65 + (random() % 26);
+	}
+	printf("Before sort\n");
+
+	for(i=0; i<MAX; i++)
+	{
+		printf("b[%d]= %c\n",i,b[i]);
+	}
+
+	if(foo ==1 )
+	{
+		sort(a,sizeof(int), MAX,ascend);
+		sort(b,sizeof(char),MAX,charAscend);
+	}
+	else if(foo ==2)
+	{
+		sort(a,sizeof(int), MAX,descend);
+		sort(b,sizeof(char),MAX,charDescend);
+	}
 
 
-    //1. Create an array with randomly initialized data
-    //2. Sort our array with a function 2 function pointers
-    //  - first compareTo is < 
-    //  - second compreTo is >
+	printf("----------------------\n");
+	printf("After sort\n");
 
-    return 0;
+	for(i=0; i<MAX; i++)
+	{
+		printf("b[%d]= %c\n",i,b[i]);
+	}
+
+
+	//1. Create an array with randomly initialized data
+	//2. Sort our array with a function 2 function pointers
+	//  - first compareTo is <
+	//  - second compreTo is >
+
+	return 0;
 }

--- a/C-examples/function-pointers/test-qsort.c
+++ b/C-examples/function-pointers/test-qsort.c
@@ -13,7 +13,7 @@
  */
 int compareInt(const void *x, const void *y)
 {
-        return ((*(int *)x) - (*(int *)y));
+	return ((*(int *)x) - (*(int *)y));
 
 	/* the statement above produces the same result as the following */
 	/*
@@ -25,7 +25,8 @@ int compareInt(const void *x, const void *y)
 	*/
 }
 
-struct student {
+struct student
+{
 	int id;
 	char *name;
 	char *address;
@@ -40,11 +41,11 @@ struct student {
  */
 int compareId(const void *x, const void *y)
 {
-		int key1, key2;
-		key1 = ((struct student *)x)->id;
-		key2 = ((struct student *)y)->id;
-		return (key1 - key2);
-		/* return (((struct student *)x)->id - ((struct student *)y)->id); */
+	int key1, key2;
+	key1 = ((struct student *)x)->id;
+	key2 = ((struct student *)y)->id;
+	return (key1 - key2);
+	/* return (((struct student *)x)->id - ((struct student *)y)->id); */
 }
 
 int main(int argc, char **argv)
@@ -62,11 +63,12 @@ int main(int argc, char **argv)
 
 	n = atoi(argv[1]);
 
-        // Show how to use qsort to sort an array of random ints.
+	// Show how to use qsort to sort an array of random ints.
 	array = (int *) malloc(sizeof(int)*n);
 
-        srandom(0);
-	for (i=0; i<n; i++) {
+	srandom(0);
+	for (i=0; i<n; i++)
+	{
 		array[i] = random() % 1000;
 	}
 
@@ -83,15 +85,16 @@ int main(int argc, char **argv)
 	printf("\n");
 
 
-        // Show how to use same qsort to sort an array of student structs.
+	// Show how to use same qsort to sort an array of student structs.
 	roster = (struct student *) malloc(sizeof(struct student)*n);
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		roster[i].id = n-i;
 		roster[i].name = NULL;
 		roster[i].address = NULL;
 	}
 
-        printf("unsorted array\n");
+	printf("unsorted array\n");
 	for (i=0; i<n; i++)
 		printf(" %d %s\n", roster[i].id, roster[i].name);
 	printf("\n");

--- a/C-examples/gdb/arrays.c
+++ b/C-examples/gdb/arrays.c
@@ -32,8 +32,10 @@ int main(int argc, char **argv)
 	C = (int *) malloc(sizeof(int)*100); // C points to an array of n int's
 	for (i =0; i<100; i++)
 		C[i] = 1;
-	
-	tmp = B; B = C; C = tmp; // swap B and C
+
+	tmp = B;
+	B = C;
+	C = tmp; // swap B and C
 
 	// delete the arrays that B and C point to
 	free(B);
@@ -52,7 +54,7 @@ int main(int argc, char **argv)
 
 	// print out the 2-dimensional array
 	for (i=0; i<n; i++)
-	{		
+	{
 		for (j=0; j<n; j++)
 			printf(" %d",X[i][j]);
 		printf("\n");
@@ -61,7 +63,7 @@ int main(int argc, char **argv)
 
 	// delete the 2-dimensional array X
 	for (i=0; i<n; i++)
-			free(X[i]);
+		free(X[i]);
 	free(X);
 
 	//create  triangular shaped 2-dimensional array
@@ -76,8 +78,9 @@ int main(int argc, char **argv)
 
 	// print out the triangular array
 	for (i=0; i<n; i++)
-	{		
-		for (j=0; j<=i; j++) {
+	{
+		for (j=0; j<=i; j++)
+		{
 			printf("%3d ",Y[i][j]);
 		}
 		printf("\n");
@@ -85,7 +88,7 @@ int main(int argc, char **argv)
 
 	// delete the 2-dimensional array Y
 	for (i=0; i<n; i++)
-			free(Y[i]);
+		free(Y[i]);
 	free(Y);
 
 	exit(0); // normal termination

--- a/C-examples/gdb/faulty1.c
+++ b/C-examples/gdb/faulty1.c
@@ -2,7 +2,7 @@
 
 /*
  * Example to illustrate pointers/arrays in C
- * 
+ *
  * Index out of bounds error.
  */
 
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
 		A[i] = i;
 
 	B = (int *) malloc(sizeof(int)*100);
-	
+
 	/* This is legal, but not good! */
 	for (i =0; i<110; i++)
 		B[i] = i;
@@ -33,8 +33,10 @@ int main(int argc, char **argv)
 	/* This should cause an error! */
 	for (i =0; i<100; i++)
 		C[i] = 1;
-	
-	tmp = B; B = C; C = tmp; // swap B and C
+
+	tmp = B;
+	B = C;
+	C = tmp; // swap B and C
 
 	// delete the arrays that B and C point to
 	free(B);

--- a/C-examples/gdb/function.c
+++ b/C-examples/gdb/function.c
@@ -5,20 +5,22 @@ static int count =0;
 
 static void print_it(int size, int *b)
 {
-    int i;
-    for(i = 0; i < size; b++, i++){
-        printf("%p %d\n",b,*b);
-    }
+	int i;
+	for(i = 0; i < size; b++, i++)
+	{
+		printf("%p %d\n",b,*b);
+	}
 
 }
 
 static void populate(int size, int *b)
 {
-    int i;
-    count++;
-    for(i = 0; i < size; b++, i++){
-        *b = i;
-    }
+	int i;
+	count++;
+	for(i = 0; i < size; b++, i++)
+	{
+		*b = i;
+	}
 }
 
 
@@ -30,20 +32,21 @@ static void populate(int size, int *b)
 
 void not_buggy(int size, int *b)
 {
-    int z = rand()%10;
-    if(z == 5){
-        free(b);
-        b = NULL;
-    }
-    populate(20,b);
-    print_it(20,b);
+	int z = rand()%10;
+	if(z == 5)
+	{
+		free(b);
+		b = NULL;
+	}
+	populate(20,b);
+	print_it(20,b);
 }
 
 
 int main(void)
 {
-    int *stuff = (int*)malloc(sizeof(int)*20);
-    for(;;) not_buggy(20,stuff);
+	int *stuff = (int*)malloc(sizeof(int)*20);
+	for(;;) not_buggy(20,stuff);
 }
 
 

--- a/C-examples/gdb/lists.c
+++ b/C-examples/gdb/lists.c
@@ -5,16 +5,17 @@
 
 /*
 
-	lists.c 
+	lists.c
 		Contains functions to manipulate a linked list.
- 
+
  */
 
 
 NodePtr ReverseList(NodePtr L)
 {
 	NodePtr list = NULL;
-	while (L != NULL) {
+	while (L != NULL)
+	{
 		NodePtr tmp = L;
 		L = L->next;
 		tmp->next = list;
@@ -26,13 +27,14 @@ NodePtr ReverseList(NodePtr L)
 void PrintList(NodePtr L)
 {
 	int count = 0;
-	while (L) {
+	while (L)
+	{
 		printf(" %d -->",L->item);
 		L = L->next;
 		count++;
 	}
-    printf(" NULL \n");
+	printf(" NULL \n");
 }
- 
-		
+
+
 

--- a/C-examples/gdb/loop.c
+++ b/C-examples/gdb/loop.c
@@ -9,8 +9,9 @@ int main()
 	int status;
 	pid_t pid;
 
-	for(;;){
-		sleep(5); 
+	for(;;)
+	{
+		sleep(5);
 		pid=fork();
 		if (pid == 0)
 		{

--- a/C-examples/gdb/strings.c
+++ b/C-examples/gdb/strings.c
@@ -5,7 +5,7 @@
 
 #define MAXLEN 256
 
-int main() 
+int main()
 {
 	char *r = "winnie";
 	char *s;
@@ -32,19 +32,19 @@ int main()
 		printf("r < s (lexicographically)\n");
 	else if (stat == 0)
 		printf("r == s (lexicographically)\n");
-	else 
+	else
 		printf("r > s (lexicographically)\n");
-	
 
 
-	
+
+
 	free(s);
 	s = (char *) malloc(sizeof(char)*MAXLEN);
 	strcpy(s, " tigger pooh abracadabra woo ;; woo & choo choo");
 
 	/* save a copy because strtok will eat it up */
 	save = (char *) malloc(sizeof(char)*(strlen(s)+1));
-	strcpy(save, s); 
+	strcpy(save, s);
 
 	printf("starting to tokenize the string: %s \n", s);
 	/* tokenize the string q */
@@ -72,5 +72,5 @@ int main()
 		token = strsep(&s,  " ;");
 	}
 	exit(0);
-	
-} 
+
+}

--- a/C-examples/gdb/test-lists.c
+++ b/C-examples/gdb/test-lists.c
@@ -5,27 +5,31 @@
 
 
 int main(int argc, char **argv)
-{	
+{
 	int i;
 	int n;
 	NodePtr L, prev, list;
 
-	if (argc != 2) {
-			fprintf(stderr, "Usage: %s <list size> \n",argv[0]);
-			exit(1);
+	if (argc != 2)
+	{
+		fprintf(stderr, "Usage: %s <list size> \n",argv[0]);
+		exit(1);
 	}
 	n = atoi(argv[1]);
 
-	L = NULL; prev = L;
-	for (i=n; i>0; i--) {
+	L = NULL;
+	prev = L;
+	for (i=n; i>0; i--)
+	{
 		L = (NodePtr) malloc(sizeof(struct node));
-		if (L == NULL) {
-			printf("Error allocating node for linked list\n");	
+		if (L == NULL)
+		{
+			printf("Error allocating node for linked list\n");
 			exit(1);
 		}
-		L->next = prev; 
+		L->next = prev;
 		L->item = i;
-        prev = L;
+		prev = L;
 	}
 
 	PrintList(L);

--- a/C-examples/intro/badexample.c
+++ b/C-examples/intro/badexample.c
@@ -1,7 +1,7 @@
 
 
 #include <stdio.h>
-/* 
+/*
    We are expecting 4 command line arguments:
    the first one a string, the next an integer, the next a float
    and the last one a double
@@ -11,15 +11,17 @@ int main(int argc, char *argv[])
 {
 	int i;
 
-	if (argc != 5) {
+	if (argc != 5)
+	{
 		fprintf(stderr, "Usage: %s <string> <int> <float> <double>\n", argv[0]);
 		return 1;
 	}
 
-	for (i=0; i<argc; i++) {
+	for (i=0; i<argc; i++)
+	{
 		printf("argument %d = %s\n", argv[0]);
 		printf("argument %d = %s\n", atoi(argv[1]));
-		/* 
+		/*
 		   atof() converts to a double only
 		   strtod(...)/strtof(...) convert to double/float and
 		   do better error handling. strtof(...) was added in ANSI C'99

--- a/C-examples/intro/cmdline-str.c
+++ b/C-examples/intro/cmdline-str.c
@@ -13,31 +13,39 @@ void printUsage(char[]);
 
 int main(int argc, char *argv[])
 {
-	if(argc < 5) {
+	if(argc < 5)
+	{
 		printUsage(argv[0]);
 	}
 
 	// Parse int argument
 	unsigned int x = 0;
-	if(strcmp(argv[1],"-i") == 0) {
+	if(strcmp(argv[1],"-i") == 0)
+	{
 		int temp = atoi(argv[2]);
-		if (temp > UINT_MAX || temp < 0) {
+		if (temp > UINT_MAX || temp < 0)
+		{
 			printf("error: integer (%d) must be between %u and %u\n\n",
 			       temp, 0, UINT_MAX);
 			printUsage(argv[0]);
 		}
 		// only keep the value if it is in valid range
 		x = (unsigned int) temp;
-	} else {
+	}
+	else
+	{
 		printf("error: -i expected\n");
 		printUsage(argv[0]);
 	}
 
 	// Parse string argument
 	char *string; // This is like a String Object reference in Java
-	if(strcmp(argv[3], "-s") == 0) {
+	if(strcmp(argv[3], "-s") == 0)
+	{
 		string = argv[4];
-	} else {
+	}
+	else
+	{
 		printf("error: -s expected\n");
 		printUsage(argv[0]);
 	}
@@ -47,7 +55,8 @@ int main(int argc, char *argv[])
 
 	int i;
 	int len = (int) strlen(string);
-	for(i = 0; i < len; i++) {
+	for(i = 0; i < len; i++)
+	{
 		printf("%d: %c\n", i, string[i]);
 	}
 

--- a/C-examples/intro/cmdline.c
+++ b/C-examples/intro/cmdline.c
@@ -3,7 +3,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-/* 
+/*
    We are expecting 4 command line arguments:
    the first one a string, the next an integer, the next a double.
    Recall that the name of the executable is always passed in as the first
@@ -13,12 +13,13 @@
 
 int main(int argc, char *argv[])
 {
-	if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr, "Usage: %s <string> <int> <float>\n", argv[0]);
 		return 1;
 	}
 
-    printf("argument count = %d\n", argc);
+	printf("argument count = %d\n", argc);
 
 	printf("argument %d = %s\n", 0, argv[0]);
 	printf("argument %d = %s\n", 1, argv[1]);

--- a/C-examples/intro/conv.c
+++ b/C-examples/intro/conv.c
@@ -17,13 +17,13 @@ int main()
 	float x = 0;
 	double y = 2E300;
 
-    printf("Before m = n;\n int m: %d\n long n: %ld\n", m, n);
+	printf("Before m = n;\n int m: %d\n long n: %ld\n", m, n);
 	m = n;
 	printf("After m = n;\n int m: %d\n long n: %ld\n", m, n);
 
 	printf("\n");
 
-    printf("Before x = y;\n float x: %e\n double y: %le\n", x, y);
+	printf("Before x = y;\n float x: %e\n double y: %le\n", x, y);
 	x = y;
 	printf("After x = y;\n float x: %e\n double y: %le\n", x, y);
 

--- a/C-examples/intro/count-digits.c
+++ b/C-examples/intro/count-digits.c
@@ -23,7 +23,7 @@ int main()
 			++nwhite;
 		}
 		else
-        	{
+		{
 			++nother;
 		}
 	}

--- a/C-examples/intro/cp1.c
+++ b/C-examples/intro/cp1.c
@@ -13,7 +13,8 @@ int main(int argc, char *argv[])
 	int c;  // why is this int and not char?
 
 	c = getchar();
-	while (c != EOF ) {
+	while (c != EOF )
+	{
 		putchar(c);
 		c = getchar();
 	}

--- a/C-examples/intro/cp2.c
+++ b/C-examples/intro/cp2.c
@@ -11,11 +11,12 @@ int main(int argc, char *argv[])
 	/* The parentheses around c = getchar() are required because
 	   the operator != has higher precedence than = operator */
 
-	while ((c = getchar()) != EOF ) {
+	while ((c = getchar()) != EOF )
+	{
 		putchar(c);
-                printf("hello");
+		printf("hello");
 
-        }
+	}
 
 	return 0;
 }

--- a/C-examples/intro/helloworld.c
+++ b/C-examples/intro/helloworld.c
@@ -9,6 +9,6 @@
 int main(void)
 {
 	printf("Hello World!\n");
-        //O means normal termination, non zero means abnormal termination
-	return 0; 
+	//O means normal termination, non zero means abnormal termination
+	return 0;
 }

--- a/C-examples/intro/printtest.c
+++ b/C-examples/intro/printtest.c
@@ -2,15 +2,16 @@
 
 
 
-int main(void){
-    float pi = 113.14159f;
-    printf("Testing the formatting of printf\n");
-    printf("Original question from quiz\n");
-    printf("Value of pi is : %d, %f, %1.2f, %1.4f\n", (int) pi, pi, pi, pi);
-    printf("The test !!!\n");
-    printf("Value of pi is : %d, %f, %.2f, %.4f\n", (int) pi, pi, pi, pi);
+int main(void)
+{
+	float pi = 113.14159f;
+	printf("Testing the formatting of printf\n");
+	printf("Original question from quiz\n");
+	printf("Value of pi is : %d, %f, %1.2f, %1.4f\n", (int) pi, pi, pi, pi);
+	printf("The test !!!\n");
+	printf("Value of pi is : %d, %f, %.2f, %.4f\n", (int) pi, pi, pi, pi);
 
 
-    return 0;
+	return 0;
 
 }

--- a/C-examples/intro/range.c
+++ b/C-examples/intro/range.c
@@ -6,25 +6,25 @@
 
 int main ()
 {
-  printf("%25s %25s %25s\n", "Type", "Min", "Max");
+	printf("%25s %25s %25s\n", "Type", "Min", "Max");
 
-  printf("%25s %25d %25d\n", "char", CHAR_MIN, CHAR_MAX);
-  printf("%25s %25u %25u\n", "unsigned char", 0, UCHAR_MAX);
+	printf("%25s %25d %25d\n", "char", CHAR_MIN, CHAR_MAX);
+	printf("%25s %25u %25u\n", "unsigned char", 0, UCHAR_MAX);
 
-  printf("%25s %25d %25d\n", "short", SHRT_MIN, SHRT_MAX);
-  printf("%25s %25u %25u\n", "unsigned short",0, USHRT_MAX);
+	printf("%25s %25d %25d\n", "short", SHRT_MIN, SHRT_MAX);
+	printf("%25s %25u %25u\n", "unsigned short",0, USHRT_MAX);
 
-  printf("%25s %25d %25d\n", "int", INT_MIN, INT_MAX);
-  printf("%25s %25u %25u\n", "unsigned int", 0, UINT_MAX);
+	printf("%25s %25d %25d\n", "int", INT_MIN, INT_MAX);
+	printf("%25s %25u %25u\n", "unsigned int", 0, UINT_MAX);
 
-  printf("%25s %25ld %25ld\n", "long", LONG_MIN, LONG_MAX);
-  printf("%25s %25lu %25lu\n", "unsigned long", 0UL, ULONG_MAX); 
-  /* 0UL makes 0 unsigned long int type, otherwise 0 would be a signed int by default */
+	printf("%25s %25ld %25ld\n", "long", LONG_MIN, LONG_MAX);
+	printf("%25s %25lu %25lu\n", "unsigned long", 0UL, ULONG_MAX);
+	/* 0UL makes 0 unsigned long int type, otherwise 0 would be a signed int by default */
 
-  printf("%25s %25e %25e\n", "float", FLT_MIN, FLT_MAX);
-  printf("%25s %25e %25e\n", "double", DBL_MIN, DBL_MAX);
-  printf("%25s %25Le %25Le\n", "long double", LDBL_MIN, LDBL_MAX);
+	printf("%25s %25e %25e\n", "float", FLT_MIN, FLT_MAX);
+	printf("%25s %25e %25e\n", "double", DBL_MIN, DBL_MAX);
+	printf("%25s %25Le %25Le\n", "long double", LDBL_MIN, LDBL_MAX);
 
-  return 0;
+	return 0;
 }
 

--- a/C-examples/intro/static.c
+++ b/C-examples/intro/static.c
@@ -2,19 +2,19 @@
 
 int keepItStatic(int x)
 {
-    static int y = 0;
-    y = x + y;
-    return y;
+	static int y = 0;
+	y = x + y;
+	return y;
 }
 
 int main(int argc, char **argv)
 {
-    int i;
-    for(i = 0; i < 5; i++)
-    {
-        int result = keepItStatic(i);
-        printf("[%d] result: %d\n", i, result);
-    }
+	int i;
+	for(i = 0; i < 5; i++)
+	{
+		int result = keepItStatic(i);
+		printf("[%d] result: %d\n", i, result);
+	}
 
-    return 0;
+	return 0;
 }

--- a/C-examples/intro/wc1.c
+++ b/C-examples/intro/wc1.c
@@ -9,7 +9,8 @@ int main(int argc, char *argv[])
 	long nc;
 
 	nc = 0;
-	while (getchar() != EOF ) {
+	while (getchar() != EOF )
+	{
 		nc++;
 	}
 	printf("%ld\n", nc);
@@ -19,7 +20,7 @@ int main(int argc, char *argv[])
 
 /* An alternate way of writing the above */
 /*
- int main() 
+ int main()
  {
  	double nc;
 

--- a/C-examples/intro/wc2.c
+++ b/C-examples/intro/wc2.c
@@ -8,15 +8,15 @@
 int main(int argc, char *argv[])
 {
 	int c;
-   	long nl;	
+	long nl;
 
 	nl = 0;
 	while ((c = getchar()) != EOF )
-    {
+	{
 		if (c == '\n')
-        {
-            nl++;
-        }
+		{
+			nl++;
+		}
 	}
 	printf("%ld\n", nl);
 	return 0;

--- a/C-examples/intro/wc3.c
+++ b/C-examples/intro/wc3.c
@@ -12,24 +12,28 @@
 int main(int argc, char *argv[])
 {
 	int c;
-   	long nc, nw, nl;
+	long nc, nw, nl;
 	int state;
 
 	state = OUT;
 	nl = nw = nc = 0;
-	while ((c = getchar()) != EOF ) {
-	        nc++;
-	        if (c == '\n') {
-                        nl++;
-                }
+	while ((c = getchar()) != EOF )
+	{
+		nc++;
+		if (c == '\n')
+		{
+			nl++;
+		}
 
-                if (c == ' ' || c == '\n' || c == '\t') {
-	                state = OUT;
-                }
-                else if (state == OUT) {
-		        state = IN;
-		        nw++;
-	        }
+		if (c == ' ' || c == '\n' || c == '\t')
+		{
+			state = OUT;
+		}
+		else if (state == OUT)
+		{
+			state = IN;
+			nw++;
+		}
 	}
 
 	printf("nl: %ld nw: %ld nc: %ld\n", nl, nw, nc);

--- a/C-examples/linked-lists/buggy-list/Job.c
+++ b/C-examples/linked-lists/buggy-list/Job.c
@@ -6,7 +6,7 @@ JobPtr createJob(int jobid, char *info)
 	JobPtr newJob = (JobPtr) malloc (sizeof(Job));
 	newJob->jobid = jobid;
 	newJob->info = (char *) malloc(sizeof(char)*(strlen(info)+1));
-	strcpy(newJob->info, info); 
+	strcpy(newJob->info, info);
 	return newJob;
 }
 

--- a/C-examples/linked-lists/buggy-list/List.c
+++ b/C-examples/linked-lists/buggy-list/List.c
@@ -5,9 +5,9 @@
 
 /*
 
-	list.c 
+	list.c
 		Contains functions to manipulate a doubly-linked list.
- 
+
 */
 
 
@@ -51,7 +51,9 @@ void addAtFront(ListPtr list, NodePtr node)
 	{
 		list->head = node;
 		list->tail = node;
-	} else {
+	}
+	else
+	{
 		list->head->prev = node;
 		list->head = node;
 	}
@@ -103,7 +105,8 @@ static void print(NodePtr node)
 	int count = 0;
 	char *buf;
 
-	while (node) {
+	while (node)
+	{
 		buf = toString(node->data);
 		printf(" %s -->", buf);
 		free(buf);
@@ -112,12 +115,12 @@ static void print(NodePtr node)
 		if ((count % 6) == 0)
 			printf("\n");
 	}
-    printf(" NULL \n");
+	printf(" NULL \n");
 }
- 
+
 
 void freeList(ListPtr L)
 {
 }
-		
+
 

--- a/C-examples/linked-lists/buggy-list/RandomTestList.c
+++ b/C-examples/linked-lists/buggy-list/RandomTestList.c
@@ -20,48 +20,50 @@ void runRandomTests(int count, unsigned int seed, int n, ListPtr list)
 	NodePtr node;
 	JobPtr job;
 
-   	srandom(seed);
-    for (i=0; i<count; i++) {
-        test = random() % NUM_TESTS;
-        switch (test) {
-            case 0:
-				if (DEBUG > 1) fprintf(stderr,"addAtFront\n");
-                n++;
-                job = createJob(n, "some info");
-                node = createNode(job);
-                addAtFront(list, node);
-                break;
-            case 1:
-				if (DEBUG > 1) fprintf(stderr,"addAtRear\n");
-                n++;
-                job = createJob(n, "some info");
-                node = createNode(job);
-                addAtRear(list, node);
-                break;
-            case 2:
-				if (DEBUG > 1) fprintf(stderr,"removeFront\n");
-                node = removeFront(list);
-                break;
-            case 3:
-				if (DEBUG > 1) fprintf(stderr,"removeRear\n");
-                node = removeRear(list);
-                break;
-            case 4:
-				if (DEBUG > 1) fprintf(stderr,"removeNode\n");
-                node = removeNode(list, search(list, i));
-                break;
-            case 5:
-				if (DEBUG > 1) fprintf(stderr,"reverseList\n");
-                reverseList(list);
+	srandom(seed);
+	for (i=0; i<count; i++)
+	{
+		test = random() % NUM_TESTS;
+		switch (test)
+		{
+		case 0:
+			if (DEBUG > 1) fprintf(stderr,"addAtFront\n");
+			n++;
+			job = createJob(n, "some info");
+			node = createNode(job);
+			addAtFront(list, node);
+			break;
+		case 1:
+			if (DEBUG > 1) fprintf(stderr,"addAtRear\n");
+			n++;
+			job = createJob(n, "some info");
+			node = createNode(job);
+			addAtRear(list, node);
+			break;
+		case 2:
+			if (DEBUG > 1) fprintf(stderr,"removeFront\n");
+			node = removeFront(list);
+			break;
+		case 3:
+			if (DEBUG > 1) fprintf(stderr,"removeRear\n");
+			node = removeRear(list);
+			break;
+		case 4:
+			if (DEBUG > 1) fprintf(stderr,"removeNode\n");
+			node = removeNode(list, search(list, i));
+			break;
+		case 5:
+			if (DEBUG > 1) fprintf(stderr,"reverseList\n");
+			reverseList(list);
 
-            default:
-                break;
-        }
-    }
+		default:
+			break;
+		}
+	}
 }
 
 int main(int argc, char **argv)
-{	
+{
 	int i;
 	int n;
 	int count;
@@ -71,16 +73,19 @@ int main(int argc, char **argv)
 	JobPtr job;
 	ListPtr list;
 
-	if (argc < 2) {
+	if (argc < 2)
+	{
 		fprintf(stderr, "Usage: %s <list size> [<test size=list size>] [<seed>] \n",argv[0]);
 		exit(1);
 	}
 	n = atoi(argv[1]);
 	count = n;
-	if (argc >= 3) {
+	if (argc >= 3)
+	{
 		count = atoi(argv[2]);
 	}
-	if (argc == 4) {
+	if (argc == 4)
+	{
 		seed = atoi(argv[3]);
 	}
 

--- a/C-examples/linked-lists/buggy-list/SimpleTestList.c
+++ b/C-examples/linked-lists/buggy-list/SimpleTestList.c
@@ -9,16 +9,17 @@
 
 
 int main(int argc, char **argv)
-{	
+{
 	int i;
 	int n;
 	NodePtr node;
 	JobPtr job;
 	ListPtr list;
 
-	if (argc != 2) {
-			fprintf(stderr, "Usage: %s <list size> \n",argv[0]);
-			exit(1);
+	if (argc != 2)
+	{
+		fprintf(stderr, "Usage: %s <list size> \n",argv[0]);
+		exit(1);
 	}
 	n = atoi(argv[1]);
 

--- a/C-examples/linked-lists/doubly-linked/libsrc/List.c
+++ b/C-examples/linked-lists/doubly-linked/libsrc/List.c
@@ -3,8 +3,8 @@
 #include "List.h"
 
 struct list * createList(int (*equals)(const void *,const void *),
-			 char * (*toString)(const void *),
-			 void (*freeObject)(void *))
+                         char * (*toString)(const void *),
+                         void (*freeObject)(void *))
 {
 	struct list *list;
 	list = (struct list *) malloc(sizeof(struct list));
@@ -38,10 +38,13 @@ void addAtFront(struct list *list, struct node *node)
 	list->size++;
 	node->next = list->head;
 	node->prev = NULL;
-	if (list->head == NULL) {
+	if (list->head == NULL)
+	{
 		list->head = node;
 		list->tail = node;
-	} else {
+	}
+	else
+	{
 		list->head->prev = node;
 		list->head = node;
 	}
@@ -81,7 +84,8 @@ void printList(const struct list *list)
 	int count = 0;
 	char *output;
 	struct node *temp = list->head;
-	while (temp) {
+	while (temp)
+	{
 		output = list->toString(temp->obj);
 		printf(" %s -->",output);
 		free(output);

--- a/C-examples/linked-lists/doubly-linked/testsuite/Object.c
+++ b/C-examples/linked-lists/doubly-linked/testsuite/Object.c
@@ -23,12 +23,12 @@ char *toString(const void *obj)
 	struct object* myobj = (struct object*) obj;
 
 	// calculate and allocate enough space for the output string.
-        int max_data_len = strlen(myobj->data)+1;
+	int max_data_len = strlen(myobj->data)+1;
 	max_data_len += MAX_KEY_DIGITS;
-        max_data_len += 3; // include [] and space
+	max_data_len += 3; // include [] and space
 	char *temp = (char *) malloc(sizeof(char) * max_data_len);
 
-        //print into our buffer safely
+	//print into our buffer safely
 	snprintf(temp, max_data_len, "[%d] %s", myobj->key, myobj->data);
 	return temp;
 }

--- a/C-examples/linked-lists/doubly-linked/testsuite/RandomTestList.c
+++ b/C-examples/linked-lists/doubly-linked/testsuite/RandomTestList.c
@@ -13,123 +13,129 @@ const int DEBUG = 0;
 
 void print_stats(int *tests)
 {
-  printf(" ========================\n");
-  printf(" Function  #invocations\n");
-  printf(" ========================\n");
-  printf(" addAtFront  %d \n", tests[0]);
-  printf(" addAtRear   %d \n", tests[1]);
-  printf(" removeFront %d \n", tests[2]);
-  printf(" removeRear  %d \n", tests[3]);
-  printf(" removeNode  %d \n", tests[4]);
-  printf(" reverseList %d \n", tests[5]);
-  printf(" search      %d \n", tests[6]);
-  printf(" ========================\n");
+	printf(" ========================\n");
+	printf(" Function  #invocations\n");
+	printf(" ========================\n");
+	printf(" addAtFront  %d \n", tests[0]);
+	printf(" addAtRear   %d \n", tests[1]);
+	printf(" removeFront %d \n", tests[2]);
+	printf(" removeRear  %d \n", tests[3]);
+	printf(" removeNode  %d \n", tests[4]);
+	printf(" reverseList %d \n", tests[5]);
+	printf(" search      %d \n", tests[6]);
+	printf(" ========================\n");
 }
 
 void runRandomTests(int count, unsigned int seed, int n, struct list* list)
 {
-  int i;
-  int test;
-  struct node* node;
-  struct object* job;
-  struct object* searchJob;
-  int *tests;
+	int i;
+	int test;
+	struct node* node;
+	struct object* job;
+	struct object* searchJob;
+	int *tests;
 
-  tests = (int *) malloc(sizeof(int)*NUM_TESTS);
-  for (i=0; i<NUM_TESTS; i++)
-    tests[i]=0;
-  srandom(seed);
-  for (i=0; i<count; i++) {
-    test = (int) (NUM_TESTS * (double) rand()/RAND_MAX);
-    tests[test]++;
-    switch (test) {
-    case 0:
-      if (DEBUG > 1) fprintf(stderr,"addAtFront\n");
-      n++;
-      job = createObject(n, "some info");
-      node = createNode(job);
-      addAtFront(list, node);
-      break;
-    case 1:
-      if (DEBUG > 1) fprintf(stderr,"addAtRear\n");
-      n++;
-      job = createObject(n, "some info");
-      node = createNode(job);
-      addAtRear(list, node);
-      break;
-    case 2:
-      if (DEBUG > 1) fprintf(stderr,"removeFront\n");
-      node = removeFront(list);
-      freeNode(node, freeObject);
-      break;
-    case 3:
-      if (DEBUG > 1) fprintf(stderr,"removeRear\n");
-      node = removeRear(list);
-      freeNode(node, freeObject);
-      break;
-    case 4:
-      if (DEBUG > 1) fprintf(stderr,"removeNode\n");
-      searchJob = createObject(i,"foo");
-      node = removeNode(list, search(list, searchJob));
-      freeNode(node, freeObject);
-      freeObject(searchJob);
-      break;
-    case 5:
-      if (DEBUG > 1) fprintf(stderr,"reverseList\n");
-      reverseList(list);
-      break;
-    case 6:
-      if (DEBUG > 1) fprintf(stderr,"searchList\n");
-      searchJob = createObject(i,"foo");
-      node = search(list, searchJob);
-      freeObject(searchJob);
-      break;
-    default:
-      break;
-    }
-  }
-  print_stats(tests);
-  free(tests);
+	tests = (int *) malloc(sizeof(int)*NUM_TESTS);
+	for (i=0; i<NUM_TESTS; i++)
+		tests[i]=0;
+	srandom(seed);
+	for (i=0; i<count; i++)
+	{
+		test = (int) (NUM_TESTS * (double) rand()/RAND_MAX);
+		tests[test]++;
+		switch (test)
+		{
+		case 0:
+			if (DEBUG > 1) fprintf(stderr,"addAtFront\n");
+			n++;
+			job = createObject(n, "some info");
+			node = createNode(job);
+			addAtFront(list, node);
+			break;
+		case 1:
+			if (DEBUG > 1) fprintf(stderr,"addAtRear\n");
+			n++;
+			job = createObject(n, "some info");
+			node = createNode(job);
+			addAtRear(list, node);
+			break;
+		case 2:
+			if (DEBUG > 1) fprintf(stderr,"removeFront\n");
+			node = removeFront(list);
+			freeNode(node, freeObject);
+			break;
+		case 3:
+			if (DEBUG > 1) fprintf(stderr,"removeRear\n");
+			node = removeRear(list);
+			freeNode(node, freeObject);
+			break;
+		case 4:
+			if (DEBUG > 1) fprintf(stderr,"removeNode\n");
+			searchJob = createObject(i,"foo");
+			node = removeNode(list, search(list, searchJob));
+			freeNode(node, freeObject);
+			freeObject(searchJob);
+			break;
+		case 5:
+			if (DEBUG > 1) fprintf(stderr,"reverseList\n");
+			reverseList(list);
+			break;
+		case 6:
+			if (DEBUG > 1) fprintf(stderr,"searchList\n");
+			searchJob = createObject(i,"foo");
+			node = search(list, searchJob);
+			freeObject(searchJob);
+			break;
+		default:
+			break;
+		}
+	}
+	print_stats(tests);
+	free(tests);
 }
 
 int main(int argc, char **argv)
 {
-  int i;
-  int n;
-  int count;
-  unsigned int seed=0;
+	int i;
+	int n;
+	int count;
+	unsigned int seed=0;
 
-  struct object* job;
-  struct node* node;
-  struct list* list;
+	struct object* job;
+	struct node* node;
+	struct list* list;
 
-  if (argc < 2) {
-    fprintf(stderr, "Usage: %s <list size> [<test size=list size>] [<seed>] \n",argv[0]);
-    exit(1);
-  }
-  n = atoi(argv[1]);
-  count = n;
-  if (argc >=  3) {
-    count = atoi(argv[2]);
-  }
-  if (argc == 4) {
-    seed = atoi(argv[3]);
-  }
+	if (argc < 2)
+	{
+		fprintf(stderr, "Usage: %s <list size> [<test size=list size>] [<seed>] \n",argv[0]);
+		exit(1);
+	}
+	n = atoi(argv[1]);
+	count = n;
+	if (argc >=  3)
+	{
+		count = atoi(argv[2]);
+	}
+	if (argc == 4)
+	{
+		seed = atoi(argv[3]);
+	}
 
-  list = createList(equals, toString, freeObject);
-  for (i=0; i<n; i++) {
-      job = createObject(i, "args");
-      node = createNode(job);
-      addAtFront(list, node);
-    }
+	list = createList(equals, toString, freeObject);
+	for (i=0; i<n; i++)
+	{
+		job = createObject(i, "args");
+		node = createNode(job);
+		addAtFront(list, node);
+	}
 
-  runRandomTests(count, seed, n, list);
+	runRandomTests(count, seed, n, list);
 
-  if (DEBUG > 0)
-    printList(list);
+	if (DEBUG > 0)
+		printList(list);
 
-  freeList(list);
-  exit(0);
+	freeList(list);
+	exit(0);
 }
 
 /* vim: set tabstop=4: */

--- a/C-examples/linked-lists/doubly-linked/testsuite/SimpleTestList.c
+++ b/C-examples/linked-lists/doubly-linked/testsuite/SimpleTestList.c
@@ -22,7 +22,7 @@ char *toString(const void *obj)
 
 void freeObject(void *obj)
 {
-    free(obj);
+	free(obj);
 }
 
 int main(int argc, char **argv)
@@ -34,7 +34,8 @@ int main(int argc, char **argv)
 
 	n=1000;
 	list = createList(equals, toString, freeObject);
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		object = (int *) malloc(sizeof(int));
 		*object = i;
 		node = createNode(object);

--- a/C-examples/linked-lists/doubly-linked/testsuite/UnitTestList.c
+++ b/C-examples/linked-lists/doubly-linked/testsuite/UnitTestList.c
@@ -29,9 +29,12 @@ void printTestInfo(char* testName, char *info)
 
 void printTestResult(char* testName, int passed)
 {
-	if(passed){
+	if(passed)
+	{
 		fprintf(stdout, "%s - %s\n\n", "[PASSED]", testName);
-	}else{
+	}
+	else
+	{
 		fprintf(stdout, "%s - %s\n\n", "[FAILED]", testName);
 	}
 }

--- a/C-examples/linked-lists/singly-linked/SimpleTest.c
+++ b/C-examples/linked-lists/singly-linked/SimpleTest.c
@@ -9,16 +9,19 @@ int main(int argc, char **argv)
 	struct node *list;
 	struct node *node;
 
-	if (argc != 2) {
+	if (argc != 2)
+	{
 		fprintf(stderr, "Usage: %s <list size> \n",argv[0]);
 		exit(1);
 	}
 	n = atoi(argv[1]);
 
 	list = NULL;
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		node = (struct node*) malloc(sizeof(struct node));
-		if (node == NULL) {
+		if (node == NULL)
+		{
 			printf("Error allocating node for linked list\n");
 			exit(1);
 		}

--- a/C-examples/linked-lists/singly-linked/SinglyLinkedList.c
+++ b/C-examples/linked-lists/singly-linked/SinglyLinkedList.c
@@ -10,10 +10,13 @@
 struct node *addAtFront(struct node *head, struct node *node)
 {
 	if (node == NULL) return head;
-	if (head == NULL) {
+	if (head == NULL)
+	{
 		head = node;
 		node->next = NULL;
-	} else {
+	}
+	else
+	{
 		node->next = head;
 		head = node;
 	}
@@ -24,7 +27,8 @@ struct node *addAtFront(struct node *head, struct node *node)
 struct node* reverseList(struct node *head)
 {
 	struct node *list = NULL;
-	while (head) {
+	while (head)
+	{
 		struct node *tmp = head;
 		head = head->next;
 		tmp->next = list;
@@ -36,7 +40,8 @@ struct node* reverseList(struct node *head)
 
 void printList(struct node *head)
 {
-	while (head) {
+	while (head)
+	{
 		printf(" %d -->",head->item);
 		head = head->next;
 	}

--- a/C-examples/objects/Address.c
+++ b/C-examples/objects/Address.c
@@ -6,7 +6,7 @@
 static int getLength(Address this)
 {
 	return strlen(this->name)+strlen(this->streetAddress)+
-				strlen(this->city)+strlen(this->state)+4+5+10;
+	       strlen(this->city)+strlen(this->state)+4+5+10;
 }
 
 Address createAddress(char *name, char *streetAddress, char *city,
@@ -34,7 +34,7 @@ char *printMultiLine(Address this)
 	int len = getLength(this);
 	char * temp = (char *) malloc(sizeof(char)*len);
 	snprintf(temp, len, "%s\n%s\n%s, %s, %d\n", this->name,
-				this->streetAddress, this->city, this->state, this->zip);
+	         this->streetAddress, this->city, this->state, this->zip);
 	return temp;
 }
 
@@ -43,7 +43,7 @@ char *printOneLine(Address this)
 	int len = getLength(this);
 	char * temp = (char *) malloc(sizeof(char)*len);
 	snprintf(temp, len, "%s, %s, %s, %s %d\n", this->name,
-				this->streetAddress, this->city, this->state, this->zip);
+	         this->streetAddress, this->city, this->state, this->zip);
 	return temp;
 }
 

--- a/C-examples/objects/testAddress.c
+++ b/C-examples/objects/testAddress.c
@@ -10,10 +10,10 @@
 int main(int argc, char *argv[])
 {
 	Address addr1 = createAddress("Moo Shoo", "123 Main Street", "Boise",
-                                      "Idaho", 83701, printOneLine);
+	                              "Idaho", 83701, printOneLine);
 
 	Address addr2 = createAddress("Hee Haw", "123 Main Street", "Boise",
-                                      "Idaho", 83701, NULL);
+	                              "Idaho", 83701, NULL);
 
 
 	/* uses the default printMultiLine */

--- a/C-examples/pointers-and-arrays/1d-arrays.c
+++ b/C-examples/pointers-and-arrays/1d-arrays.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
 	C = (int *) malloc(sizeof(int)*n); // C points to an array of n int's
 	for (i =0; i<n; i++)
 		C[i] = 1;  /* equivalent to *(C+i) */
-	
+
 	// swap B and C
 	tmp = B;
 	B = C;

--- a/C-examples/pointers-and-arrays/2d-arrays.c
+++ b/C-examples/pointers-and-arrays/2d-arrays.c
@@ -15,9 +15,11 @@ int main(int argc, char **argv)
 
 
 	X = (int ***) malloc(n * sizeof(int **));
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		X[i] = (int **) malloc(n * sizeof(int *));
-		for(j = 0; j <n; j++) {
+		for(j = 0; j <n; j++)
+		{
 			X[i][j] = (int *) malloc(n *sizeof(int));
 		}
 	}
@@ -31,8 +33,10 @@ int main(int argc, char **argv)
 
 
 	// delete the 2-dimensional array X
-	for (i=0; i<n; i++) {
-		for(j=0;j<n;j++) {
+	for (i=0; i<n; i++)
+	{
+		for(j=0; j<n; j++)
+		{
 			free(X[i][j]);
 		}
 		free(X[i]);

--- a/C-examples/pointers-and-arrays/array-bounds.c
+++ b/C-examples/pointers-and-arrays/array-bounds.c
@@ -31,8 +31,8 @@ int main(int argc, char* argv[])
 	pa = a;
 	pa--;
 	for(i = 0; i < 10; i++)
-                printf("%d ", pa[i]);
-        printf("\n");
+		printf("%d ", pa[i]);
+	printf("\n");
 
 	return 0;
 }

--- a/C-examples/pointers-and-arrays/test-const-ptr.c
+++ b/C-examples/pointers-and-arrays/test-const-ptr.c
@@ -3,13 +3,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void foo(const int *x) {
-	    int *tmp = x;
-		*tmp = 5;
-		/* try *x = 5 */
+void foo(const int *x)
+{
+	int *tmp = x;
+	*tmp = 5;
+	/* try *x = 5 */
 }
 
-int main() {
+int main()
+{
 
 	int *x = malloc(sizeof(int));
 	foo(x);

--- a/C-examples/scope/scope1.c
+++ b/C-examples/scope/scope1.c
@@ -43,7 +43,7 @@ int main (int argc, char **argv)
 	double z;
 	int x;
 
-    if (argc != 3)
+	if (argc != 3)
 	{
 		fprintf(stderr,"Usage: %s <int> <double> \n",argv[0]);
 		exit(1); //exit and return unsuccessful status to the shell

--- a/C-examples/strings/reverse.c
+++ b/C-examples/strings/reverse.c
@@ -5,30 +5,34 @@
 /*
  * Simple function to reverse a string using indexes
  */
-void reverse(char foo[]){
-    int f = 0;
-    int b = strlen(foo)-1;
-    char tmp = ' ';
-    while(f < b){
-        tmp = foo[f];
-        foo[f] = foo[b];
-        foo[b] = tmp;
-        f++;b--;
-    }
+void reverse(char foo[])
+{
+	int f = 0;
+	int b = strlen(foo)-1;
+	char tmp = ' ';
+	while(f < b)
+	{
+		tmp = foo[f];
+		foo[f] = foo[b];
+		foo[b] = tmp;
+		f++;
+		b--;
+	}
 }
 
 int main(int argc, char *argv[])
 {
-    if(argc !=2){
-        printf("usage: %s <string>\n",argv[0]);
-        exit(EXIT_SUCCESS);
-    }
-    int len = strlen(argv[1]) +1;
-    char tmp[len];
-    strcpy(tmp,argv[1]);
-    reverse(tmp);
-    printf("%s\n",tmp);
-    return (EXIT_SUCCESS);
+	if(argc !=2)
+	{
+		printf("usage: %s <string>\n",argv[0]);
+		exit(EXIT_SUCCESS);
+	}
+	int len = strlen(argv[1]) +1;
+	char tmp[len];
+	strcpy(tmp,argv[1]);
+	reverse(tmp);
+	printf("%s\n",tmp);
+	return (EXIT_SUCCESS);
 }
 
 

--- a/C-examples/strings/strings-ex1.c
+++ b/C-examples/strings/strings-ex1.c
@@ -10,7 +10,7 @@
 
 /*char c = '\0';*/
 
-int main() 
+int main()
 {
 	char *r = "winnie";
 	char *s;
@@ -33,9 +33,9 @@ int main()
 		printf("r < s (lexicographically)\n");
 	else if (stat == 0)
 		printf("r == s (lexicographically)\n");
-	else 
+	else
 		printf("r > s (lexicographically)\n");
-	
+
 	free(s);
 	exit(0);
 }

--- a/C-examples/strings/strings-ex2.c
+++ b/C-examples/strings/strings-ex2.c
@@ -7,7 +7,7 @@
 
 const int MAX_LENGTH = 1024;
 
-int main() 
+int main()
 {
 	char *token;
 	char *save;
@@ -20,7 +20,7 @@ int main()
 
 	/* save a copy because strtok will eat it up */
 	save = (char *) malloc(sizeof(char)*(strlen(s)+1));
-	strcpy(save, s); 
+	strcpy(save, s);
 
 	printf("starting to tokenize the string: %s\n", s);
 	/* tokenize the string q */
@@ -33,4 +33,4 @@ int main()
 
 	s = save; /* restore s */
 	return 0;
-} 
+}

--- a/C-examples/strings/strings-ex3.c
+++ b/C-examples/strings/strings-ex3.c
@@ -25,13 +25,13 @@ int main(int argc, char **argv)
 
 	s = (char *) malloc(sizeof(char) * MAX_LENGTH);
 	strcpy(s, " tigger pooh abracadabra woo ;; woo & choo choo");
-    // (strcpy is okay here because we know that our src string is less than
-    // MAX_LENGTH. However, if we didn't know the length of our src string
-    // ahead of time, we would want to use strncpy.)
+	// (strcpy is okay here because we know that our src string is less than
+	// MAX_LENGTH. However, if we didn't know the length of our src string
+	// ahead of time, we would want to use strncpy.)
 
 	/* save a copy because strtok will eat it up */
 	save = (char *) malloc(sizeof(char)*(strlen(s)+1));
-	strcpy(save, s); 
+	strcpy(save, s);
 
 	token = (char **) malloc (sizeof(char *) * MAX_TOKENS);
 	/* tokenize the string s */

--- a/C-examples/structures/structs-ex0.c
+++ b/C-examples/structures/structs-ex0.c
@@ -7,14 +7,15 @@ int main(int argc, char *argv[])
 {
 	int n = 3;
 
-	struct string {
+	struct string
+	{
 		int len;
 		char *str;
 	} *p, *p2;
 
 	p = (struct string *) malloc(sizeof(struct string) * n);
 	p2 = p;
-	
+
 	int i, j;
 	char c = 'a';
 	for(i = 0; i < n; i++)
@@ -33,33 +34,33 @@ int main(int argc, char *argv[])
 		printf("[%d] len: %d, str:  %s\n", i, p[i].len, p[i].str);
 	}
 
-	printf("\np: %p, p->len: %d\n", p, p->len); 
+	printf("\np: %p, p->len: %d\n", p, p->len);
 	int newlen = ++p->len;
 	printf("(%s)\n\tp: %p, newlen: %d\n", "++p->len", p, newlen);
-	
+
 	newlen = (++p)->len;
 	printf("(%s)\n\tp: %p, newlen: %d\n", "(++p)->len", p, newlen);
-	
+
 	newlen = (p++)->len;
 	printf("(%s)\n\tp: %p, newlen: %d\n", "(p++)->len", p, newlen);
-	
+
 	newlen = p->len;
-        printf("(%s)\n\tp: %p, newlen: %d\n", "p->len", p, newlen);
+	printf("(%s)\n\tp: %p, newlen: %d\n", "p->len", p, newlen);
 
 
-	printf("\np2: %p, p2->str: %p (%s)\n", p2, p2->str, p2->str); 
+	printf("\np2: %p, p2->str: %p (%s)\n", p2, p2->str, p2->str);
 	char newstr = *p2->str;
 	printf("(%s)\n\tp2: %p, p2->str: %p (%s), newstr: %c\n", "*p2->str", p2,  p2->str, p2->str, newstr);
-	
+
 	newstr = *p2->str++;
 	printf("(%s)\n\tp2: %p, p2->str: %p (%s), newstr: %c\n", "*p2->str++", p2, p2->str, p2->str, newstr);
-	
+
 	newstr = (*p2->str)++;
 	printf("(%s)\n\tp2: %p, p2->str: %p (%s), newstr: %c\n", "(*p2->str)++", p2, p2->str, p2->str, newstr);
-	
+
 	newstr = *p2++->str;
 	printf("(%s)\n\tp2: %p, p2->str: %p (%s), newstr: %c\n", "*p2++->str", p2, p2->str, p2->str, newstr);
-	
+
 	newstr = *p2->str;
 	printf("(%s)\n\tp2: %p, p2->str: %p (%s), newstr: %c\n", "*p2->str", p2, p2->str, p2->str, newstr);
 

--- a/C-examples/unions/union1.c
+++ b/C-examples/unions/union1.c
@@ -1,32 +1,42 @@
 #include <stdio.h>
 
-enum utype{
-  INT,
-  DOUBLE,
-  STRING
+enum utype
+{
+	INT,
+	DOUBLE,
+	STRING
 };
 
-struct data {
-	union udata {
-   		int ival;
-    	double dval;
-    	char *sval;
+struct data
+{
+	union udata
+	{
+		int ival;
+		double dval;
+		char *sval;
 	} data;
-    enum utype storedType;
-}; 
+	enum utype storedType;
+};
 
 
 void printData(struct data value)
 {
-	switch (value.storedType) {
-		case INT: printf("ival = %d \n", value.data.ival); break;
-		case DOUBLE: printf("fval = %f \n", value.data.dval); break;
-		case STRING : printf("sval = %s \n", value.data.sval); break;
+	switch (value.storedType)
+	{
+	case INT:
+		printf("ival = %d \n", value.data.ival);
+		break;
+	case DOUBLE:
+		printf("fval = %f \n", value.data.dval);
+		break;
+	case STRING :
+		printf("sval = %s \n", value.data.sval);
+		break;
 	}
 }
 
 
-int main(int argc, char **argv) 
+int main(int argc, char **argv)
 {
 
 	struct data myCloset;

--- a/C-examples/using-C++-compiler-for-C-programs/arrays.cc
+++ b/C-examples/using-C++-compiler-for-C-programs/arrays.cc
@@ -16,14 +16,16 @@ int main(int argc, char **argv)
 	// one dimensional arrays
 	int A[100];
 	for (int i=0; i<100; i++)
-			A[i] = i;
+		A[i] = i;
 
 	// B points to an array of 100 int's
 	int *B = new int[100];
 	int n = 10;
 	int *C = new int[n]; // C points to an array of n int's
-	
-	int *tmp = B; B = C; C = tmp; // swap B and C
+
+	int *tmp = B;
+	B = C;
+	C = tmp; // swap B and C
 
 	// delete the arrays that B and C point to
 	delete [] B;
@@ -31,9 +33,9 @@ int main(int argc, char **argv)
 
 
 	// two dimensional arrays
-	int **X = new int*[n]; 
+	int **X = new int*[n];
 	for (int i=0; i<n; i++)
-		X[i] = new int[n]; 
+		X[i] = new int[n];
 
 
 	// initialize the 2-dimensional array
@@ -43,22 +45,22 @@ int main(int argc, char **argv)
 
 	// print out the 2-dimensional array
 	for (int i=0; i<n; i++)
-	{		
+	{
 		for (int j=0; j<n; j++)
 			cout <<  " " << X[i][j];
-		cout << "\n"; 
+		cout << "\n";
 	}
 
 
 	// delete the 2-dimensional array X
 	for (int i=0; i<n; i++)
-			delete [] X[i];
+		delete [] X[i];
 	delete [] X;
 
 	//create  triangular shaped 2-dimensional array
 	int **Y = new int*[n];
 	for (int i=0; i<n; i++)
-		Y[i] = new int[i+1]; 
+		Y[i] = new int[i+1];
 
 
 	// initialize the triangular array
@@ -68,16 +70,17 @@ int main(int argc, char **argv)
 
 	// print out the triangular array
 	for (int i=0; i<n; i++)
-	{		
-		for (int j=0; j<=i; j++) {
+	{
+		for (int j=0; j<=i; j++)
+		{
 			cout << setw(3) << Y[i][j];
 		}
-		cout << "\n"; 
+		cout << "\n";
 	}
 
 	// delete the 2-dimensional array Y
 	for (int i=0; i<n; i++)
-			delete [] Y[i];
+		delete [] Y[i];
 	delete [] Y;
 
 	exit(0); // normal termination

--- a/C-examples/using-C++-compiler-for-C-programs/pointers.cc
+++ b/C-examples/using-C++-compiler-for-C-programs/pointers.cc
@@ -11,7 +11,7 @@ int main(int argc, char **argv)
 {
 	int z1 = 15;
 
-	int *y = new int; 
+	int *y = new int;
 	*y = z1;
 	printf("y = %d\n",*y);
 
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
 
 
 	int **x = new int*;
-	*x = new int; 
+	*x = new int;
 	**x = 5;
 	printf("&x = %p  x = %p *x = %p  **x = %d \n",&x, x, *x, **x);
 

--- a/C-examples/using-C++-compiler-for-C-programs/test-qsort.cc
+++ b/C-examples/using-C++-compiler-for-C-programs/test-qsort.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 int compare(const void *x, const void *y)
 {
-		return ((*(int *)x) - (*(int *)y));
+	return ((*(int *)x) - (*(int *)y));
 }
 
 int main(int argc, char **argv)

--- a/C-examples/valgrind/sample.c
+++ b/C-examples/valgrind/sample.c
@@ -1,16 +1,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 #define SIZE 100
-int main() {
-  int i, sum = 0;
-  int *a = malloc(SIZE);
-  for(i=0;i<SIZE;++i) sum += a[i];
-  a[26] = 1;
-  a = NULL;
-  if(sum > 0) printf("Hi!\n");
-  return 0;
+int main()
+{
+	int i, sum = 0;
+	int *a = malloc(SIZE);
+	for(i=0; i<SIZE; ++i) sum += a[i];
+	a[26] = 1;
+	a = NULL;
+	if(sum > 0) printf("Hi!\n");
+	return 0;
 }
 
 /*
- * Source: http://haifux.org/lectures/239/ 
+ * Source: http://haifux.org/lectures/239/
  */

--- a/C-examples/varargs/test-varargs.c
+++ b/C-examples/varargs/test-varargs.c
@@ -12,7 +12,8 @@ void strlist(int n, ...)
 	char *s;
 
 	va_start(ap, n);
-	while (1) {
+	while (1)
+	{
 		s = va_arg(ap, char *);
 		if (n==0) break;
 		printf("%s\n",s);
@@ -23,7 +24,8 @@ void strlist(int n, ...)
 
 
 
-int main() {
+int main()
+{
 
 
 	printf("Calling with three arguments\n");
@@ -31,10 +33,10 @@ int main() {
 
 	printf("Calling with two arguments\n");
 	strlist(2, "string1", "string3");
-	
+
 	printf("Calling with 0 arguments\n");
 	strlist(0);
 
-    exit(0);
+	exit(0);
 }
 

--- a/files-processes/fork-and-exec-xlogo.c
+++ b/files-processes/fork-and-exec-xlogo.c
@@ -8,27 +8,33 @@ void err_sys(char *msg);
 
 int main(int argc, char **argv)
 {
-    pid_t  pids[4], pid;
-    int i, status;
+	pid_t  pids[4], pid;
+	int i, status;
 
-    for (i=0; i<4; i++) {
-        if ((pid = fork()) == 0) {
-		execlp("xlogo", "xlogo", (char *) 0);
-		// if we get here, something went wrong
-		/* fprintf(stderr, "Child %d (%d): ", i, getpid()); */
-		/* perror("execlp failed"); */
-        } else if (pid > 0) {
-		pids[i] = pid;
-		printf("pids[%d] is %d\n",i,pids[i]);
-        } else {
-		err_sys("fork error");
-        }
-    }
+	for (i=0; i<4; i++)
+	{
+		if ((pid = fork()) == 0)
+		{
+			execlp("xlogo", "xlogo", (char *) 0);
+			// if we get here, something went wrong
+			/* fprintf(stderr, "Child %d (%d): ", i, getpid()); */
+			/* perror("execlp failed"); */
+		}
+		else if (pid > 0)
+		{
+			pids[i] = pid;
+			printf("pids[%d] is %d\n",i,pids[i]);
+		}
+		else
+		{
+			err_sys("fork error");
+		}
+	}
 
-    /* other code */
-    for (i = 0; i < 3; i++)
-        waitpid(-1, &status, 0);
-    exit(0);
+	/* other code */
+	for (i = 0; i < 3; i++)
+		waitpid(-1, &status, 0);
+	exit(0);
 }
 
 void err_sys(char *msg)

--- a/files-processes/fork-and-exec.c
+++ b/files-processes/fork-and-exec.c
@@ -32,9 +32,12 @@ int main(int argc, char *argv[])
 	}
 	else if (pid == 0)	/* child */
 	{
-		if(argc == 1) {
+		if(argc == 1)
+		{
 			execlp("./print-pid","print-pid",(char *) NULL);
-		} else if(argc == 2) {
+		}
+		else if(argc == 2)
+		{
 			char *url = buildQueryUrl(argv[1]);
 			execlp("google-chrome","google-chrome", "--new-window", url, (char *) NULL);
 			/* execlp("gvim","gvim", argv[1], (char *) NULL); */

--- a/files-processes/fork-and-wait.c
+++ b/files-processes/fork-and-wait.c
@@ -27,10 +27,10 @@ int main(void)
 
 	/* parent continues concurrently with child */
 
-	#ifdef DEBUG
+#ifdef DEBUG
 	printf("Created child with pid %d\n",pid);
 	sleep(4);
-	#endif
+#endif
 
 	printf("Shoo away!\n");
 
@@ -44,15 +44,15 @@ int main(void)
 
 void childs_play()
 {
-	#ifdef DEBUG
+#ifdef DEBUG
 	sleep(3);
-	#endif
+#endif
 
 	printf("Hey, I need some money! \n");
 
-	#ifdef DEBUG
+#ifdef DEBUG
 	sleep(1);
-	#endif
+#endif
 }
 
 void err_sys(char *msg)

--- a/files-processes/fork-hello-world.c
+++ b/files-processes/fork-hello-world.c
@@ -16,9 +16,9 @@ int main(void)
 	char *message1 = "Goodbye";
 	char *message2 = "World";
 
-	#if DEBUG
+#if DEBUG
 	printf("\n\nbefore fork\n");
-	#endif
+#endif
 
 	if ((pid = fork()) < 0)
 	{
@@ -27,15 +27,15 @@ int main(void)
 	else if (pid == 0)	/* first child */
 	{
 		print_message_function(message1);
-		#if DEBUG
+#if DEBUG
 		sleep(2);
-		#endif
+#endif
 		exit(EXIT_SUCCESS);
 	}
 
-	#if DEBUG
+#if DEBUG
 	printf("Created child with pid %d\n",pid);
-	#endif
+#endif
 
 	/* parent continues and creates another child */
 	if ((pid = fork()) < 0)
@@ -46,15 +46,15 @@ int main(void)
 	{
 		print_message_function(message2);
 		printf("\n");
-		#if DEBUG
+#if DEBUG
 		sleep(2);
-		#endif
+#endif
 		exit(EXIT_SUCCESS);
 	}
-	#if DEBUG
+#if DEBUG
 	printf("Created child with pid %d\n",pid);
 	sleep(2);
-	#endif
+#endif
 	exit(EXIT_SUCCESS);
 }
 

--- a/files-processes/mycp.c
+++ b/files-processes/mycp.c
@@ -2,7 +2,7 @@
 /*
  * A simple file copy example. Not for use on directories or links.
  */
- 
+
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -19,34 +19,37 @@ int main(int argc, char * argv[]);
 int main(int argc, char *argv[])
 {
 	int src, dst, in, out;
-    char buf[BUF_SIZE];
+	char buf[BUF_SIZE];
 	int bufsize;
 
-    if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr,"Usage: %s <buffer size> <src> <dest>\n", argv[0]);
 		exit(EX_USAGE);
-	}		
+	}
 	bufsize = atoi(argv[1]);
-	if (bufsize > BUF_SIZE) {
+	if (bufsize > BUF_SIZE)
+	{
 		fprintf(stderr,"Error: %s: max. buffer size is %d\n",argv[0], BUF_SIZE);
 		exit(EX_USAGE);
-	}	
+	}
 
-    src = open(argv[2], O_RDONLY);
-    if (src < 0) exit(EX_NOINPUT);
-    dst = creat(argv[3], MODE);
+	src = open(argv[2], O_RDONLY);
+	if (src < 0) exit(EX_NOINPUT);
+	dst = creat(argv[3], MODE);
 	if (dst < 0) exit(EX_CANTCREAT);
 
-    while (1) {
+	while (1)
+	{
 		in = read(src, buf, bufsize);
-        if (in <= 0) break;
+		if (in <= 0) break;
 		out = write(dst, buf, in);
-        if (out <= 0) break;
+		if (out <= 0) break;
 	}
 
 	close(src);
-    close(dst);
-    exit(EXIT_SUCCESS);
+	close(dst);
+	exit(EXIT_SUCCESS);
 }
 
 /* vim: set ts=4: */

--- a/files-processes/numcpus.c
+++ b/files-processes/numcpus.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-int main() 
+int main()
 {
 	printf("number of CPUs = %ld\n", sysconf(_SC_NPROCESSORS_CONF));
 	exit(EXIT_SUCCESS);

--- a/files-processes/pow2Tester.c
+++ b/files-processes/pow2Tester.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
 	{
 		timeVal = atoi(argv[1]);
 		if (argc > 2)
-		{ 
+		{
 			seed = atoi(argv[2]);
 			if (argc > 3)
 				modVal = atoi(argv[3]);

--- a/files-processes/print-buffer-sizes.c
+++ b/files-processes/print-buffer-sizes.c
@@ -28,6 +28,6 @@ int main(void)
 void pr_stdio(const char *name, FILE *fp)
 {
 	printf("stream = %s, ", name);
-				/* following is nonportable to non Linux systems */
+	/* following is nonportable to non Linux systems */
 	printf(", buffer size = %ld\n", fp->_IO_buf_end - fp->_IO_buf_base);
 }

--- a/files-processes/simple-shell.c
+++ b/files-processes/simple-shell.c
@@ -1,7 +1,7 @@
-/* 
+/*
   lab/files-processes/simple-shell.c
-  This program needs the file error.c and ourhdr.h to compile. 
- 
+  This program needs the file error.c and ourhdr.h to compile.
+
  */
 #include	<sys/types.h>
 #include	<sys/wait.h>
@@ -14,13 +14,15 @@ int main(void)
 	int		status;
 
 	printf("%% ");	/* print prompt (printf requires %% to print %) */
-	while (fgets(buf, MAXLINE, stdin) != NULL) {
+	while (fgets(buf, MAXLINE, stdin) != NULL)
+	{
 		buf[strlen(buf) - 1] = '\0';	/* replace newline with null */
 
 		if ( (pid = fork()) < 0)
 			err_sys("fork error");
 
-		else if (pid == 0) {		/* child */
+		else if (pid == 0)  		/* child */
+		{
 			execlp(buf, buf, (char *) 0);
 			err_ret("couldn't execute: %s", buf);
 			exit(EXIT_FAILURE);

--- a/files-processes/stdc-mycp.c
+++ b/files-processes/stdc-mycp.c
@@ -11,50 +11,53 @@ int main(int argc, char *argv[])
 	char buf[BUF_SIZE];
 	int bufsize;
 
-	if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr, "Usage: %s <buffer size> <src> <dest>\n", argv[0]);
 		return (1);
 	}
-	
+
 	bufsize = atoi(argv[1]);
-	if (bufsize > BUF_SIZE) {
+	if (bufsize > BUF_SIZE)
+	{
 		fprintf(stderr,"Error: %s: max. buffer size is %d\n",argv[0], BUF_SIZE);
 		return (1);
-	}	
+	}
 
 	src = fopen(argv[2], "r");
-	if (NULL == src) 
+	if (NULL == src)
 		return (2);
 //	setbuf(src, NULL);     // disables internal buffer stream
-		
+
 	dst = fopen(argv[3], "w");
-	if (dst < 0) 
+	if (dst < 0)
 		return (3);
 //	setbuf(dst, NULL);     // disables internal buffer stream
 
-	while (1) {
+	while (1)
+	{
 		in = fread(
-				buf,			// Storage location for data
-				1,				// Item size in bytes
-				bufsize,		// Maximum number of items to be read
-				src			// Pointer to FILE structure
-		);
+		         buf,			// Storage location for data
+		         1,				// Item size in bytes
+		         bufsize,		// Maximum number of items to be read
+		         src			// Pointer to FILE structure
+		     );
 		if (0 == in)
 			break;
-#ifdef DEBUG			
-			printf("read %ld character\n", in);
+#ifdef DEBUG
+		printf("read %ld character\n", in);
 #endif
-		
+
 		out = fwrite(
-					buf,		// Pointer to data to be written
-					1,			// Item size in bytes
-					in,		// Maximum number of items to be written
-					dst		// Pointer to FILE structure
-		);
-		if (0 == out) 
+		          buf,		// Pointer to data to be written
+		          1,			// Item size in bytes
+		          in,		// Maximum number of items to be written
+		          dst		// Pointer to FILE structure
+		      );
+		if (0 == out)
 			break;
-#ifdef DEBUG			
-			printf("wrote %ld character\n", out);
+#ifdef DEBUG
+		printf("wrote %ld character\n", out);
 #endif
 	}
 

--- a/files-processes/timeout.c
+++ b/files-processes/timeout.c
@@ -23,28 +23,31 @@ int main(int argc, char *argv[])
 
 	/*signal(SIGINT, SIG_IGN);*/
 	progname = argv[0];
-	if (argc > 1 && argv[1][0] == '-') {
+	if (argc > 1 && argv[1][0] == '-')
+	{
 		sec = atoi(&argv[1][1]);
 		argc--;
 		argv++;
 	}
 
-	if (argc < 2) {
+	if (argc < 2)
+	{
 		error("Usage: %s [-10] command", progname);
 	}
 
 	signal(SIGALRM, onalarm);
 	alarm(sec);
-	if ((pid=fork()) == 0) {
+	if ((pid=fork()) == 0)
+	{
 		execvp(argv[1], &argv[1]);
 		error("couldn't start %s", argv[1]);
 	}
 	if ((wait(&status) == -1) || WIFSIGNALED(status))
-        {
-                int signo = WTERMSIG(status);
+	{
+		int signo = WTERMSIG(status);
 
 		printf("%s %s", argv[1], strsignal(signo));
-        }
+	}
 	exit(WEXITSTATUS(status));
 }
 

--- a/ms-windows/error.c
+++ b/ms-windows/error.c
@@ -95,20 +95,21 @@ static void err_doit(const char *fmt, va_list ap)
 	// Format the error message from the last failed call (if errorCode != 0)
 	// (returns # of TCHARS in message -- 0 if failed)
 	dwErrorCode = GetLastError();
-	
-	if (dwErrorCode != 0) {
-		if ( FormatMessage( 
-					FORMAT_MESSAGE_ALLOCATE_BUFFER |					// source and processing options
-					FORMAT_MESSAGE_FROM_SYSTEM |		
-					FORMAT_MESSAGE_IGNORE_INSERTS,	
-					NULL,														// message source
-					dwErrorCode,											// message identifier
-					MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// language identifier (Default language)
-					(LPTSTR) &lpMsgBuf,									// message buffer
-					0,															// maximum size of message buffer (ignored with FORMAT_MESSAGE_ALLOCATE_BUFFER set)
-					NULL														// array of message inserts
-				)
-		) 
+
+	if (dwErrorCode != 0)
+	{
+		if ( FormatMessage(
+		            FORMAT_MESSAGE_ALLOCATE_BUFFER |					// source and processing options
+		            FORMAT_MESSAGE_FROM_SYSTEM |
+		            FORMAT_MESSAGE_IGNORE_INSERTS,
+		            NULL,														// message source
+		            dwErrorCode,											// message identifier
+		            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// language identifier (Default language)
+		            (LPTSTR) &lpMsgBuf,									// message buffer
+		            0,															// maximum size of message buffer (ignored with FORMAT_MESSAGE_ALLOCATE_BUFFER set)
+		            NULL														// array of message inserts
+		        )
+		   )
 		{
 			// Display the formatted string.
 			fprintf(stderr, "Err #%d: %s", dwErrorCode, (LPSTR)lpMsgBuf );
@@ -116,10 +117,10 @@ static void err_doit(const char *fmt, va_list ap)
 			LocalFree( lpMsgBuf );
 		}
 	}
-	
+
 	// Reset the error state
 	SetLastError(0);
-	
+
 	fflush(NULL);		/* flushes all stdio output streams */
 	return;
 }

--- a/ms-windows/files-processes/alarm-test.c
+++ b/ms-windows/files-processes/alarm-test.c
@@ -6,12 +6,14 @@ HANDLE hTimer;
 
 void CALLBACK OnAlarm(PVOID lpParam, BOOLEAN timerOrWait);
 
-int main(void) {
+int main(void)
+{
 	CreateTimerQueueTimer(&hTimer, NULL, OnAlarm, NULL, 2000, 0, WT_EXECUTEONLYONCE);
 	Sleep(10000);
 }
 
-void CALLBACK OnAlarm(PVOID lpParam, BOOLEAN timerOrWait) {
+void CALLBACK OnAlarm(PVOID lpParam, BOOLEAN timerOrWait)
+{
 	DeleteTimerQueueTimer(NULL, hTimer, NULL);
 	printf("alarm function called!\n");
 }

--- a/ms-windows/files-processes/error.c
+++ b/ms-windows/files-processes/error.c
@@ -95,20 +95,21 @@ static void err_doit(const char *fmt, va_list ap)
 	// Format the error message from the last failed call (if errorCode != 0)
 	// (returns # of TCHARS in message -- 0 if failed)
 	dwErrorCode = GetLastError();
-	
-	if (dwErrorCode != 0) {
-		if ( FormatMessage( 
-					FORMAT_MESSAGE_ALLOCATE_BUFFER |					// source and processing options
-					FORMAT_MESSAGE_FROM_SYSTEM |		
-					FORMAT_MESSAGE_IGNORE_INSERTS,	
-					NULL,														// message source
-					dwErrorCode,											// message identifier
-					MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// language identifier (Default language)
-					(LPTSTR) &lpMsgBuf,									// message buffer
-					0,															// maximum size of message buffer (ignored with FORMAT_MESSAGE_ALLOCATE_BUFFER set)
-					NULL														// array of message inserts
-				)
-		) 
+
+	if (dwErrorCode != 0)
+	{
+		if ( FormatMessage(
+		            FORMAT_MESSAGE_ALLOCATE_BUFFER |					// source and processing options
+		            FORMAT_MESSAGE_FROM_SYSTEM |
+		            FORMAT_MESSAGE_IGNORE_INSERTS,
+		            NULL,														// message source
+		            dwErrorCode,											// message identifier
+		            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// language identifier (Default language)
+		            (LPTSTR) &lpMsgBuf,									// message buffer
+		            0,															// maximum size of message buffer (ignored with FORMAT_MESSAGE_ALLOCATE_BUFFER set)
+		            NULL														// array of message inserts
+		        )
+		   )
 		{
 			// Display the formatted string.
 			fprintf(stderr, "Err #%d: %s", dwErrorCode, (LPSTR)lpMsgBuf );
@@ -116,10 +117,10 @@ static void err_doit(const char *fmt, va_list ap)
 			LocalFree( lpMsgBuf );
 		}
 	}
-	
+
 	// Reset the error state
 	SetLastError(0);
-	
+
 	fflush(NULL);		/* flushes all stdio output streams */
 	return;
 }

--- a/ms-windows/files-processes/file-copy.c
+++ b/ms-windows/files-processes/file-copy.c
@@ -20,41 +20,45 @@ int main(int argc, char *argv[])
 	DWORD numOfBytesWritten;
 
 
-	if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr, "Usage: %s <buffer size> <src> <dest>\n", argv[0]);
 		ExitProcess(1);
 	}
-	
+
 	bufsize = atoi(argv[1]);
-	if (bufsize > BUF_SIZE) {
+	if (bufsize > BUF_SIZE)
+	{
 		fprintf(stderr,"Error: %s: max. buffer size is %d\n",argv[0], BUF_SIZE);
 		ExitProcess(1);
-	}	
+	}
 
 	sourceFile = CreateFile (
-		argv[2],
-		GENERIC_READ,
-		dwShareMode,
-		lpSecurityAttributes,
-		OPEN_ALWAYS,
-		FILE_ATTRIBUTE_READONLY,
-		hTemplateFile
-		);
-	if (sourceFile == INVALID_HANDLE_VALUE) {
+	                 argv[2],
+	                 GENERIC_READ,
+	                 dwShareMode,
+	                 lpSecurityAttributes,
+	                 OPEN_ALWAYS,
+	                 FILE_ATTRIBUTE_READONLY,
+	                 hTemplateFile
+	             );
+	if (sourceFile == INVALID_HANDLE_VALUE)
+	{
 		fprintf(stderr, "File open operation failed on file: %s\n", argv[2]);
 		ExitProcess(1);
 	}
 
 	destinationFile = CreateFile (
-		argv[3],
-		GENERIC_WRITE,
-		dwShareMode,
-		lpSecurityAttributes,
-		CREATE_ALWAYS,
-		FILE_ATTRIBUTE_NORMAL,
-		hTemplateFile
-		);
-	if (destinationFile == INVALID_HANDLE_VALUE) {
+	                      argv[3],
+	                      GENERIC_WRITE,
+	                      dwShareMode,
+	                      lpSecurityAttributes,
+	                      CREATE_ALWAYS,
+	                      FILE_ATTRIBUTE_NORMAL,
+	                      hTemplateFile
+	                  );
+	if (destinationFile == INVALID_HANDLE_VALUE)
+	{
 		fprintf(stderr, "File create operation failed on file: %s\n", argv[3]);
 		ExitProcess(1);
 	}

--- a/ms-windows/files-processes/fork-and-exec.c
+++ b/ms-windows/files-processes/fork-and-exec.c
@@ -18,45 +18,45 @@ int main(void)
 	si1.cb = sizeof(si1);
 	ZeroMemory( &pi, sizeof(pi) );
 
-	if ( ! CreateProcess( 
-		NULL,				// No module name (use command line)
-		"notepad",	// Command line for process
-		NULL,				// Process handle not inheritable
-		NULL,				// Thread handle not inheritable. 
-		FALSE,			// Set handle inheritance to FALSE. 
-		0,					// No creation flags. 
-		NULL,				// Use parent's environment block. 
-		NULL,				// Use parent's starting directory. 
-		&si1,				// Pointer to STARTUPINFO structure.
-		&pi )			// Pointer to PROCESS_INFORMATION struct
-	)
+	if ( ! CreateProcess(
+	            NULL,				// No module name (use command line)
+	            "notepad",	// Command line for process
+	            NULL,				// Process handle not inheritable
+	            NULL,				// Thread handle not inheritable.
+	            FALSE,			// Set handle inheritance to FALSE.
+	            0,					// No creation flags.
+	            NULL,				// Use parent's environment block.
+	            NULL,				// Use parent's starting directory.
+	            &si1,				// Pointer to STARTUPINFO structure.
+	            &pi )			// Pointer to PROCESS_INFORMATION struct
+	   )
 	{
 		// Try to format the error message from the last failed call (returns # of TCHARS in message -- 0 if failed)
-		if ( FormatMessage( 
-					FORMAT_MESSAGE_ALLOCATE_BUFFER |					// source and processing options
-					FORMAT_MESSAGE_FROM_SYSTEM |		
-					FORMAT_MESSAGE_IGNORE_INSERTS,	
-					NULL,														// message source
-					GetLastError(),										// message identifier
-					MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// language identifier (Default language)
-					(LPTSTR) &lpMsgBuf,									// message buffer
-					0,															// maximum size of message buffer (ignored with FORMAT_MESSAGE_ALLOCATE_BUFFER set)
-					NULL														// array of message inserts
-				)
-		) 
+		if ( FormatMessage(
+		            FORMAT_MESSAGE_ALLOCATE_BUFFER |					// source and processing options
+		            FORMAT_MESSAGE_FROM_SYSTEM |
+		            FORMAT_MESSAGE_IGNORE_INSERTS,
+		            NULL,														// message source
+		            GetLastError(),										// message identifier
+		            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// language identifier (Default language)
+		            (LPTSTR) &lpMsgBuf,									// message buffer
+		            0,															// maximum size of message buffer (ignored with FORMAT_MESSAGE_ALLOCATE_BUFFER set)
+		            NULL														// array of message inserts
+		        )
+		   )
 		{
 			// Display the formatted string.
 			PrintMessage( (LPSTR)lpMsgBuf );
 			// Free the buffer.
 			LocalFree( lpMsgBuf );
 		}
-		
+
 		ErrSys( "CreateProcess failed." );
 	}
 
 	printf( "Created child with pid %d\n", pi.dwProcessId );
 	/* parent continues concurrently with child */
-    Sleep(2000);
+	Sleep(2000);
 
 	WaitForSingleObject(pi.hProcess, INFINITE);
 	ExitProcess(0);
@@ -65,12 +65,12 @@ int main(void)
 
 void PrintMessage( char *szMsg )
 {
-		printf("%s ", szMsg);
+	printf("%s ", szMsg);
 }
 
 void ErrSys(char *szMsg)
 {
 	fprintf(stderr, szMsg);
-	fflush(NULL); /* flush all output streams */	
+	fflush(NULL); /* flush all output streams */
 	ExitProcess(1); /* exit abnormally */
-}		
+}

--- a/ms-windows/files-processes/fork-and-wait.c
+++ b/ms-windows/files-processes/fork-and-wait.c
@@ -4,7 +4,7 @@
 
 #define BUFFER_SIZE 256
 
-void ChildsPlay(); 
+void ChildsPlay();
 void ErrSys(char *szMsg);
 
 int main ( int argc, char *argv[] )
@@ -19,19 +19,25 @@ int main ( int argc, char *argv[] )
 	si1.cb = sizeof(si1);
 	ZeroMemory( &pi, sizeof(pi) );
 
-	// Check to see if child (arg2 = childID) or parent (1 arg) 
-	if (argc == 2) {
+	// Check to see if child (arg2 = childID) or parent (1 arg)
+	if (argc == 2)
+	{
 		// Child
 		dwChildID = atoi( argv[1] );
 
-		if (dwChildID == 1) {
+		if (dwChildID == 1)
+		{
 			ChildsPlay();
 			ExitProcess(0);
-		} else {
+		}
+		else
+		{
 			ErrSys( "Unknown child created." );
 			ExitProcess(1);
 		}
-	} else if (argc != 1) { // Parent has no args (1 = name of program, 2 = name + 1 arg, etc)
+	}
+	else if (argc != 1)     // Parent has no args (1 = name of program, 2 = name + 1 arg, etc)
+	{
 		ErrSys("Incorrect number of arguments.");
 		ExitProcess(1);
 	}
@@ -42,45 +48,45 @@ int main ( int argc, char *argv[] )
 	sprintf_s(szBuff, BUFFER_SIZE, "%s 1", argv[0]);
 
 	/* Start the child process */
-	if ( !CreateProcess( 
-		NULL,  // No module name (use command line)
-		szBuff,  // Command line
-		NULL,  // Process handle not inheritable
-		NULL,  // Thread handle not inheritable. 
-		FALSE,  // Set handle inheritance to FALSE. 
-		0,  // No creation flags. 
-		NULL,  // Use parent's environment block. 
-		NULL,  // Use parent's starting directory. 
-		&si1,  // Pointer to STARTUPINFO structure.
-		&pi )  // Pointer to PROCESS_INFORMATION struct
-	)
+	if ( !CreateProcess(
+	            NULL,  // No module name (use command line)
+	            szBuff,  // Command line
+	            NULL,  // Process handle not inheritable
+	            NULL,  // Thread handle not inheritable.
+	            FALSE,  // Set handle inheritance to FALSE.
+	            0,  // No creation flags.
+	            NULL,  // Use parent's environment block.
+	            NULL,  // Use parent's starting directory.
+	            &si1,  // Pointer to STARTUPINFO structure.
+	            &pi )  // Pointer to PROCESS_INFORMATION struct
+	   )
 	{
 		ErrSys( "CreateProcess failed." );
 	}
 
 	printf("Created child with pid %d\n", pi.dwProcessId);
 	/* parent continues concurrently with child */
-			
+
 	Sleep(2000);  // Windows Sleep() is in milliseconds
-	
+
 	printf("Shoo away!\n");
-	
+
 	/* wait for normal termination of child process */
 	WaitForSingleObject(pi.hProcess, INFINITE);
-    CloseHandle(pi.hProcess);
-    CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+	CloseHandle(pi.hThread);
 	Sleep(2000); //so we can watch the output
 	ExitProcess(0);
 }
 
 void ChildsPlay()
 {
-     printf("Hey, I need some money! \n");
+	printf("Hey, I need some money! \n");
 }
 
 void ErrSys(char *szMsg)
 {
 	fprintf(stderr, szMsg);
-	fflush(NULL); /* flush all output streams */	
+	fflush(NULL); /* flush all output streams */
 	ExitProcess(1); /* exit abnormally */
-}		
+}

--- a/ms-windows/files-processes/fork-hello-world.c
+++ b/ms-windows/files-processes/fork-hello-world.c
@@ -4,7 +4,7 @@
 
 #define BUFFER_SIZE 512
 
-void PrintMessage( void *p ); 
+void PrintMessage( void *p );
 void ErrSys(char *szMsg);
 
 int main(int argc, char *argv[])
@@ -26,24 +26,32 @@ int main(int argc, char *argv[])
 	ZeroMemory( &pi1, sizeof(pi1) );
 	ZeroMemory( &pi2, sizeof(pi2) );
 
-	// Check to see if child (arg2 = childID) or parent (1 arg) 
-	if (argc == 2) {
+	// Check to see if child (arg2 = childID) or parent (1 arg)
+	if (argc == 2)
+	{
 		// Child
 		dwChildID = atoi( argv[1] );
 
-		if (1 == dwChildID) {
+		if (1 == dwChildID)
+		{
 			PrintMessage(szMessage1);
 			/*sleep(2);*/
 			ExitProcess(0);
-		} else if (2 == dwChildID) {
+		}
+		else if (2 == dwChildID)
+		{
 			PrintMessage(szMessage2);
 			/*sleep(2);*/
 			ExitProcess(0);
-		} else {
+		}
+		else
+		{
 			ErrSys( "Unknown child created." );
 			ExitProcess(1);
 		}
-	} else if (argc != 1) { // Parent has no args (1 = name of program, 2 = name + 1 arg, etc)
+	}
+	else if (argc != 1)     // Parent has no args (1 = name of program, 2 = name + 1 arg, etc)
+	{
 		ErrSys( "Incorrect number of arguments." );
 		ExitProcess(1);
 	}
@@ -56,22 +64,22 @@ int main(int argc, char *argv[])
 	/*printf("\n\nbefore CreateProcess\n"); */
 
 	/* Start the child process */
-	if ( ! CreateProcess( 
-		NULL,  // No module name (use command line)
-		szBuff,  // Command line
-		NULL,  // Process handle not inheritable
-		NULL,  // Thread handle not inheritable. 
-		FALSE,  // Set handle inheritance to FALSE. 
-		0,  // No creation flags. 
-		NULL,  // Use parent's environment block. 
-		NULL,  // Use parent's starting directory. 
-		&si1,  // Pointer to STARTUPINFO structure.
-		&pi1 )  // Pointer to PROCESS_INFORMATION struct
-	)
+	if ( ! CreateProcess(
+	            NULL,  // No module name (use command line)
+	            szBuff,  // Command line
+	            NULL,  // Process handle not inheritable
+	            NULL,  // Thread handle not inheritable.
+	            FALSE,  // Set handle inheritance to FALSE.
+	            0,  // No creation flags.
+	            NULL,  // Use parent's environment block.
+	            NULL,  // Use parent's starting directory.
+	            &si1,  // Pointer to STARTUPINFO structure.
+	            &pi1 )  // Pointer to PROCESS_INFORMATION struct
+	   )
 	{
 		ErrSys( "CreateProcess failed." );
 	}
-	
+
 	/*printf("Created 1st child with dwProcessId %d\n", pi1.dwProcessId);*/
 
 	/* parent continues and creates another child */
@@ -82,18 +90,18 @@ int main(int argc, char *argv[])
 	/*printf("\n\nbefore CreateProcess\n"); */
 
 	/* Start the child process */
-	if ( ! CreateProcess( 
-		NULL,  // No module name (use command line)
-		szBuff,  // Command line
-		NULL,  // Process handle not inheritable
-		NULL,  // Thread handle not inheritable. 
-		FALSE,  // Set handle inheritance to FALSE. 
-		0,  // No creation flags. 
-		NULL,  // Use parent's environment block. 
-		NULL,  // Use parent's starting directory. 
-		&si2,  // Pointer to STARTUPINFO structure.
-		&pi2 )  // Pointer to PROCESS_INFORMATION struct
-	)
+	if ( ! CreateProcess(
+	            NULL,  // No module name (use command line)
+	            szBuff,  // Command line
+	            NULL,  // Process handle not inheritable
+	            NULL,  // Thread handle not inheritable.
+	            FALSE,  // Set handle inheritance to FALSE.
+	            0,  // No creation flags.
+	            NULL,  // Use parent's environment block.
+	            NULL,  // Use parent's starting directory.
+	            &si2,  // Pointer to STARTUPINFO structure.
+	            &pi2 )  // Pointer to PROCESS_INFORMATION struct
+	   )
 	{
 		ErrSys( "CreateProcess failed." );
 	}
@@ -105,14 +113,14 @@ int main(int argc, char *argv[])
 
 void PrintMessage( void *p )
 {
-		char *szMessage;
-		szMessage = (char *) p;
-		printf("%s ", szMessage);
+	char *szMessage;
+	szMessage = (char *) p;
+	printf("%s ", szMessage);
 }
 
 void ErrSys(char *szMsg)
 {
 	fprintf(stderr, szMsg);
-	fflush(NULL); /* flush all output streams */ 
+	fflush(NULL); /* flush all output streams */
 	ExitProcess(1); /* exit abnormally */
 }

--- a/ms-windows/files-processes/fork-test.c
+++ b/ms-windows/files-processes/fork-test.c
@@ -20,42 +20,46 @@ int main(int argc, char *argv[])
 	si.cb = sizeof(si);
 	ZeroMemory(&pi, sizeof(pi));
 
-	// Check to see if child (arg2 = childID) or parent (1 arg) 
-	if (argc == 2) {
+	// Check to see if child (arg2 = childID) or parent (1 arg)
+	if (argc == 2)
+	{
 		// Child
 		dwChildID = atoi(argv[1]);
 		Sleep(20 * 1000);
 		printf("Child %d exiting.\n", dwChildID);
 		ExitProcess(0);
 
-	} else if (argc != 1) { // Parent has no args (1 = name of program, 2 = name + 1 arg, etc)
+	}
+	else if (argc != 1)     // Parent has no args (1 = name of program, 2 = name + 1 arg, etc)
+	{
 		ErrSys("Incorrect number of arguments.\n");
 		ExitProcess(1);
 	}
 
 	// Parent
 
-	for (i=0; i<MAXNUM; i++) {
+	for (i=0; i<MAXNUM; i++)
+	{
 		// Fill in the command line for each child
 		sprintf_s(szBuff, BUFFER_SIZE, "%s %d", argv[0], i);
 
 		/* Start the child process */
 		if (! CreateProcess(
-			NULL,  // No module name (use command line)
-			(LPSTR)szBuff,  // Command line
-			NULL,  // Process handle not inheritable
-			NULL,  // Thread handle not inheritable. 
-			FALSE,  // Set handle inheritance to FALSE. 
-			0,  // No creation flags. 
-			NULL,  // Use parent's environment block. 
-			NULL,  // Use parent's starting directory. 
-			&si,  // Pointer to STARTUPINFO structure.
-			&pi)  // Pointer to PROCESS_INFORMATION struct
-		)
+		            NULL,  // No module name (use command line)
+		            (LPSTR)szBuff,  // Command line
+		            NULL,  // Process handle not inheritable
+		            NULL,  // Thread handle not inheritable.
+		            FALSE,  // Set handle inheritance to FALSE.
+		            0,  // No creation flags.
+		            NULL,  // Use parent's environment block.
+		            NULL,  // Use parent's starting directory.
+		            &si,  // Pointer to STARTUPINFO structure.
+		            &pi)  // Pointer to PROCESS_INFORMATION struct
+		   )
 		{
 			ErrSys("CreateProcess failed.\n");
 		}
-		
+
 		printf("Created child number %d with pid %d\n", i, pi.dwProcessId);
 	}
 
@@ -70,24 +74,26 @@ void ErrSys(char *szMsg)
 
 	// Try to format the error message from the last failed call (returns # of TCHARS in message -- 0 if failed)
 	if (FormatMessage(
-				FORMAT_MESSAGE_ALLOCATE_BUFFER |					// source and processing options
-				FORMAT_MESSAGE_FROM_SYSTEM |		
-				FORMAT_MESSAGE_IGNORE_INSERTS,	
-				NULL,														// message source
-				GetLastError(),										// message identifier
-				MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// language identifier (Default language)
-				(LPTSTR) &lpMsgBuf,									// message buffer
-				0,															// maximum size of message buffer (ignored with FORMAT_MESSAGE_ALLOCATE_BUFFER set)
-				NULL														// array of message inserts
-			)
-	) 
+	            FORMAT_MESSAGE_ALLOCATE_BUFFER |					// source and processing options
+	            FORMAT_MESSAGE_FROM_SYSTEM |
+	            FORMAT_MESSAGE_IGNORE_INSERTS,
+	            NULL,														// message source
+	            GetLastError(),										// message identifier
+	            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),	// language identifier (Default language)
+	            (LPTSTR) &lpMsgBuf,									// message buffer
+	            0,															// maximum size of message buffer (ignored with FORMAT_MESSAGE_ALLOCATE_BUFFER set)
+	            NULL														// array of message inserts
+	        )
+	   )
 	{
 		// Display the formatted string.
 		fprintf(stderr, "%s: %s \n", szMsg, (LPSTR)lpMsgBuf);
 		LocalFree(lpMsgBuf);
-	} else {
+	}
+	else
+	{
 		fprintf(stderr, "%s: Could not get system error message!\n",  szMsg);
 	}
-	fflush(NULL); /* flush all output streams */	
+	fflush(NULL); /* flush all output streams */
 	ExitProcess(1); /* exit abnormally */
 }

--- a/ms-windows/files-processes/print-buffer-sizes.c
+++ b/ms-windows/files-processes/print-buffer-sizes.c
@@ -22,7 +22,7 @@ int main(void)
 	if (getc(fp) == EOF)
 		err_sys("getc error");
 	pr_stdio("junk", fp);
-	
+
 	ExitProcess(0);
 }
 

--- a/ms-windows/files-processes/shell1.c
+++ b/ms-windows/files-processes/shell1.c
@@ -1,5 +1,5 @@
-/* 
- * This program needs the file error.c and to compile. 
+/*
+ * This program needs the file error.c and to compile.
  *
  */
 #include	<sys/types.h>
@@ -21,22 +21,23 @@ int main(void)
 	ZeroMemory( &pi, sizeof(pi) );
 
 	printf("%% ");	/* print prompt (printf requires %% to print %) */
-	while (fgets(szBuff, MAXLINE, stdin) != NULL) {
+	while (fgets(szBuff, MAXLINE, stdin) != NULL)
+	{
 		szBuff[strlen(szBuff) - 1] = 0;	/* replace newline with null */
 
 		/* Start the child process */
-		if ( ! CreateProcess( 
-			NULL,  // No module name (use command line)
-			szBuff,  // Command line
-			NULL,  // Process handle not inheritable
-			NULL,  // Thread handle not inheritable. 
-			FALSE,  // Set handle inheritance to FALSE. 
-			0,  // No creation flags. 
-			NULL,  // Use parent's environment block. 
-			NULL,  // Use parent's starting directory. 
-			&si,  // Pointer to STARTUPINFO structure.
-			&pi )  // Pointer to PROCESS_INFORMATION struct
-		)
+		if ( ! CreateProcess(
+		            NULL,  // No module name (use command line)
+		            szBuff,  // Command line
+		            NULL,  // Process handle not inheritable
+		            NULL,  // Thread handle not inheritable.
+		            FALSE,  // Set handle inheritance to FALSE.
+		            0,  // No creation flags.
+		            NULL,  // Use parent's environment block.
+		            NULL,  // Use parent's starting directory.
+		            &si,  // Pointer to STARTUPINFO structure.
+		            &pi )  // Pointer to PROCESS_INFORMATION struct
+		   )
 		{
 			err_ret( "CreateProcess failed." );
 		}

--- a/ms-windows/files-processes/stdc-mycp.c
+++ b/ms-windows/files-processes/stdc-mycp.c
@@ -11,48 +11,51 @@ int main(int argc, char *argv[])
 	char buf[BUF_SIZE];
 	int bufsize;
 
-	if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr, "Usage: %s <buffer size> <src> <dest>\n", argv[0]);
 		ExitProcess(1);
 	}
-	
+
 	bufsize = atoi(argv[1]);
-	if (bufsize > BUF_SIZE) {
+	if (bufsize > BUF_SIZE)
+	{
 		fprintf(stderr,"Error: %s: max. buffer size is %d\n",argv[0], BUF_SIZE);
 		ExitProcess(1);
-	}	
+	}
 
 	src = fopen(argv[2], "r");
-	if (NULL == src) 
+	if (NULL == src)
 		ExitProcess(2);
-		
+
 	dst = fopen(argv[3], "w");
-	if (dst < 0) 
+	if (dst < 0)
 		ExitProcess(3);
 
-	while (1) {
+	while (1)
+	{
 		in = fread(
-				buf,			// Storage location for data
-				1,				// Item size in bytes
-				bufsize,		// Maximum number of items to be read
-				src			// Pointer to FILE structure
-		);
+		         buf,			// Storage location for data
+		         1,				// Item size in bytes
+		         bufsize,		// Maximum number of items to be read
+		         src			// Pointer to FILE structure
+		     );
 		if (0 == in)
 			break;
-#ifdef DEBUG			
-			printf("read %d character\n", in);
+#ifdef DEBUG
+		printf("read %d character\n", in);
 #endif
-		
+
 		out = fwrite(
-					buf,		// Pointer to data to be written
-					1,			// Item size in bytes
-					in,		// Maximum number of items to be written
-					dst		// Pointer to FILE structure
-		);
-		if (0 == out) 
+		          buf,		// Pointer to data to be written
+		          1,			// Item size in bytes
+		          in,		// Maximum number of items to be written
+		          dst		// Pointer to FILE structure
+		      );
+		if (0 == out)
 			break;
-#ifdef DEBUG			
-			printf("wrote %d character\n", out);
+#ifdef DEBUG
+		printf("wrote %d character\n", out);
 #endif
 	}
 

--- a/ms-windows/files-processes/timeout.c
+++ b/ms-windows/files-processes/timeout.c
@@ -30,54 +30,57 @@ int main(int argc, char *argv[])
 	char *szProgName;
 	DWORD dwExitStatus;
 	char szBuff[BUFFER_SIZE];
-	
+
 
 	// Initialize data
 	ZeroMemory( &si, sizeof(si) );
 	si.cb = sizeof(si);
 	ZeroMemory( &pi, sizeof(pi) );
 	szBuff[0] = 0;
-	
+
 	// Check for optional timeout
 	szProgName = argv[0];
-	if (argc > 1 && argv[1][0] == '-') {
+	if (argc > 1 && argv[1][0] == '-')
+	{
 		sec = atoi(&argv[1][1]) * 1000; //in milliseconds
 		argc--;
 		argv++;
 	}
 
 	// Check for command
-	if (argc < 2) {
+	if (argc < 2)
+	{
 		Error("Usage: %s [-10] command", szProgName);
 	}
-	
+
 	// Build command (in case 1 or more args to command)
-	for (i=1; i<argc; i++) {
+	for (i=1; i<argc; i++)
+	{
 		strcat_s(szBuff, BUFFER_SIZE, argv[i]);
 		strcat_s(szBuff, BUFFER_SIZE,  " ");
 	}
-	
+
 	// Run command
 	/* Start the child process */
-	if ( ! CreateProcess( 
-		NULL,		// No module name (use command line)
-		szBuff,	// Command line
-		NULL,		// Process handle not inheritable
-		NULL,		// Thread handle not inheritable. 
-		FALSE,	// Set handle inheritance to FALSE. 
-		0,			// No creation flags. 
-		NULL,		// Use parent's environment block. 
-		NULL,		// Use parent's starting directory. 
-		&si,		// Pointer to STARTUPINFO structure.
-		&pi )	// Pointer to PROCESS_INFORMATION struct
-	)
+	if ( ! CreateProcess(
+	            NULL,		// No module name (use command line)
+	            szBuff,	// Command line
+	            NULL,		// Process handle not inheritable
+	            NULL,		// Thread handle not inheritable.
+	            FALSE,	// Set handle inheritance to FALSE.
+	            0,			// No creation flags.
+	            NULL,		// Use parent's environment block.
+	            NULL,		// Use parent's starting directory.
+	            &si,		// Pointer to STARTUPINFO structure.
+	            &pi )	// Pointer to PROCESS_INFORMATION struct
+	   )
 	{
 		Error( "CreateProcess failed for %s.", szBuff );
 	}
 	hChildProc = pi.hProcess;
-	
+
 	CreateTimerQueueTimer(&hTimer, NULL, onAlarm, NULL, sec, 0, WT_EXECUTEONLYONCE);
-	
+
 	// Wait for child proc to finish (either via termination by alarm or normally)
 	WaitForSingleObject(hChildProc, INFINITE);
 	GetExitCodeProcess(hChildProc, &dwExitStatus);
@@ -93,7 +96,7 @@ void Error(char *msg, char *arg)
 {
 	fprintf(stderr, msg, arg);
 	fprintf(stderr,"\n");
-	
+
 	ExitProcess(PROC_TERMINATION_CODE);
 }
 
@@ -101,7 +104,8 @@ void Error(char *msg, char *arg)
 /**
 Callback function for the alarm. Delete the timer and terminate all child processes.
 */
-void CALLBACK onAlarm(PVOID lpParam, BOOLEAN timerOrWait) {
+void CALLBACK onAlarm(PVOID lpParam, BOOLEAN timerOrWait)
+{
 	DeleteTimerQueueTimer(NULL, hTimer, NULL);
 	printf("Received alarm!\n");
 	TerminateProcess(hChildProc, CHILD_PROC_TERMINATION_CODE);

--- a/ms-windows/threads/thread-better-hello-world.c
+++ b/ms-windows/threads/thread-better-hello-world.c
@@ -1,7 +1,7 @@
 #include <windows.h>
 #include <stdio.h>
 
-DWORD WINAPI PrintMessageFunction( LPVOID ptr ); 
+DWORD WINAPI PrintMessageFunction( LPVOID ptr );
 
 int  main()
 {
@@ -9,31 +9,33 @@ int  main()
 	char *szMessage2 = "World";
 	LPHANDLE hThread1, hThread2;
 	DWORD dwThreadID1, dwThreadID2;
-	
+
 	hThread1 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			PrintMessageFunction,	// thread function
-			szMessage1,					// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID1				// thread identifier
-	);
-		
-	if (! hThread1) {
+	               NULL,							// Security Descriptor (handle not inheritable)
+	               0,								// initial stack size (default)
+	               PrintMessageFunction,	// thread function
+	               szMessage1,					// thread argument
+	               0,								// creation option (run immediately)
+	               &dwThreadID1				// thread identifier
+	           );
+
+	if (! hThread1)
+	{
 		fprintf(stderr, "Unable to create thread 1.\n");
 		ExitProcess(1);
 	}
 
 	hThread2 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			PrintMessageFunction,	// thread function
-			szMessage2,					// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID2				// thread identifier
-	);
-		
-	if (! hThread2) {
+	               NULL,							// Security Descriptor (handle not inheritable)
+	               0,								// initial stack size (default)
+	               PrintMessageFunction,	// thread function
+	               szMessage2,					// thread argument
+	               0,								// creation option (run immediately)
+	               &dwThreadID2				// thread identifier
+	           );
+
+	if (! hThread2)
+	{
 		fprintf(stderr, "Unable to create thread 2.\n");
 		ExitProcess(2);
 	}

--- a/ms-windows/threads/thread-cp-2.c
+++ b/ms-windows/threads/thread-cp-2.c
@@ -1,9 +1,9 @@
-/* 
+/*
  * Solution to Programming Assignment 1. (Amit Jain)
  * A simple solution to the synchronization problem that works for
  * most cases but is not guaranteed to work.
- * 
- */ 
+ *
+ */
 #include <windows.h>
 #include <stdio.h>
 
@@ -32,101 +32,107 @@ int readStarted=FALSE;
 DWORD WINAPI reader(LPVOID);
 DWORD WINAPI writer(LPVOID);
 
-  
+
 int main(int argc, char *argv[])
 {
 	LPHANDLE hThread1, hThread2;
 	DWORD dwThreadID1, dwThreadID2;
 	DWORD dwExitStatus;
 
-	if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr, "Usage: %s <buffer size> <src> <dest>\n", argv[0]);
 		ExitProcess(1);
-	}		
-	
+	}
+
 	bufsize = atoi(argv[1]);
-	if (bufsize > 8192) {
+	if (bufsize > 8192)
+	{
 		fprintf(stderr, "Error: %s: max. buffer size is MAX_BUF_SIZE\n",argv[0]);
 		ExitProcess(1);
-	}	
+	}
 
 
 	src = fopen(argv[2], "r");
-	if (NULL == src) 
+	if (NULL == src)
 		ExitProcess(2);
-	
+
 	dst = fopen(argv[3], "w");
-	if (NULL == dst) 
+	if (NULL == dst)
 		ExitProcess(3);
-	
+
 	readbuffer = bufA;
 	writebuffer = bufB;
 
 	/* create the reader and writer threads */
 
 	hThread1 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			reader,						// thread function
-			NULL,							// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID1				// thread identifier
-	);
-		
-	if (! hThread1) {
+	               NULL,							// Security Descriptor (handle not inheritable)
+	               0,								// initial stack size (default)
+	               reader,						// thread function
+	               NULL,							// thread argument
+	               0,								// creation option (run immediately)
+	               &dwThreadID1				// thread identifier
+	           );
+
+	if (! hThread1)
+	{
 		fprintf(stderr, "Unable to create thread 1.\n");
 		ExitProcess(4);
 	}
 
 	hThread2 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			writer,						// thread function
-			NULL,							// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID2				// thread identifier
-	);
+	               NULL,							// Security Descriptor (handle not inheritable)
+	               0,								// initial stack size (default)
+	               writer,						// thread function
+	               NULL,							// thread argument
+	               0,								// creation option (run immediately)
+	               &dwThreadID2				// thread identifier
+	           );
 
-	if (! hThread2) {
+	if (! hThread2)
+	{
 		fprintf(stderr, "Unable to create thread 2.\n");
 		ExitProcess(5);
 	}
 
-  
+
 	/* the main program (i.e. the heavyweight parent process) waits
 	 * for the threads to finish.
-	 */ 
+	 */
 	WaitForSingleObject(hThread1, INFINITE);
 	WaitForSingleObject(hThread2, INFINITE);
 
 	fclose(src);
 	fclose(dst);
-	
+
 	ExitProcess(0);
 }
-  
+
 DWORD WINAPI reader(LPVOID arg)
 {
 	char *tmp;
 
 	printf("Reader thread, file = %d\n",src->_file);
 	fflush(stdout);
-	while (1) {
+	while (1)
+	{
 		in = fread(
-				readbuffer,		// Storage location for data
-				1,					// Item size in bytes
-				bufsize,			// Maximum number of items to be read
-				src				// Pointer to FILE structure
-		);
+		         readbuffer,		// Storage location for data
+		         1,					// Item size in bytes
+		         bufsize,			// Maximum number of items to be read
+		         src				// Pointer to FILE structure
+		     );
 		readStarted=TRUE;
 		printf("read %d character\n",in);
-		if (!(flag)) {  
-			tmp = readbuffer; 
-			readbuffer = writebuffer; 
-			writebuffer = tmp;   
+		if (!(flag))
+		{
+			tmp = readbuffer;
+			readbuffer = writebuffer;
+			writebuffer = tmp;
 			flag = TRUE;
-		}	   
-		if (0 == in) 
+		}
+		if (0 == in)
 			break;
 	}
 	ExitThread(0);
@@ -142,15 +148,15 @@ void reader(void)
         in = read(src, readbuffer, bufsize);
 		readStarted=TRUE;
         printf("read %d character\n",in);
-        if (!(flag)) {  
-			tmp = readbuffer; readbuffer=writebuffer; writebuffer=tmp;   
+        if (!(flag)) {
+			tmp = readbuffer; readbuffer=writebuffer; writebuffer=tmp;
             flag = TRUE;
-        }       
+        }
         if (in <= 0) break;
     }
     pthread_exit(0);
 }
-*/ 
+*/
 
 DWORD WINAPI writer(LPVOID arg)
 {
@@ -160,28 +166,30 @@ DWORD WINAPI writer(LPVOID arg)
 	fflush(stdout);
 
 	while (!readStarted);
-	
-	while (1) {
+
+	while (1)
+	{
 		out = fwrite(
-					writebuffer,	// Pointer to data to be written
-					1,					// Item size in bytes
-					in,				// Maximum number of items to be written
-					dst				// Pointer to FILE structure
-		);
+		          writebuffer,	// Pointer to data to be written
+		          1,					// Item size in bytes
+		          in,				// Maximum number of items to be written
+		          dst				// Pointer to FILE structure
+		      );
 		printf("wrote %d character\n",out);
-		if (flag) {
-			tmp = readbuffer; 
-			readbuffer = writebuffer; 
-			writebuffer = tmp;   
+		if (flag)
+		{
+			tmp = readbuffer;
+			readbuffer = writebuffer;
+			writebuffer = tmp;
 			flag = FALSE;
-		}   
-		if (0 == out) 
+		}
+		if (0 == out)
 			break;
 	}
 	ExitThread(0);
 }
 /*
-void writer(void) 
+void writer(void)
 {
 	char *tmp;
 
@@ -189,14 +197,14 @@ void writer(void)
     fflush(stdout);
 
 	while (!readStarted);
-	
+
     while (1) {
         out = write(dst, writebuffer, in);
         printf("wrote %d character\n",out);
         if (flag) {
-			tmp = readbuffer; readbuffer=writebuffer; writebuffer=tmp;   
+			tmp = readbuffer; readbuffer=writebuffer; writebuffer=tmp;
             flag = FALSE;
-        }   
+        }
         if (out <= 0) break;
     }
     pthread_exit(0);

--- a/ms-windows/threads/thread-cp.c
+++ b/ms-windows/threads/thread-cp.c
@@ -1,8 +1,8 @@
-/* 
+/*
  * A simple attempted to the synchronization problem that works for
  * most cases but is not guaranteed to work.
- * 
- */ 
+ *
+ */
 #include <windows.h>
 #include <stdio.h>
 
@@ -28,100 +28,106 @@ int flag = READ;
 DWORD WINAPI reader(LPVOID);
 DWORD WINAPI writer(LPVOID);
 
-  
+
 int main(int argc, char *argv[])
 {
 	HANDLE hThread1, hThread2;
 	DWORD dwThreadID1, dwThreadID2;
 
-	if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr, "Usage: %s <buffer size> <src> <dest>\n", argv[0]);
 		ExitProcess(1);
-	}		
-	
+	}
+
 	bufsize = atoi(argv[1]);
-	if (bufsize > 8192) {
+	if (bufsize > 8192)
+	{
 		fprintf(stderr, "Error: %s: max. buffer size is MAX_BUF_SIZE\n",argv[0]);
 		ExitProcess(1);
-	}	
+	}
 
 	src = fopen(argv[2], "r");
-	if (NULL == src) 
+	if (NULL == src)
 		ExitProcess(2);
-	
+
 	dst = fopen(argv[3], "w");
-	if (NULL == dst) 
+	if (NULL == dst)
 		ExitProcess(3);
-	
+
 	/* create the reader and writer threads */
 
 	hThread1 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			reader,						// thread function
-			NULL,							// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID1				// thread identifier
-	);
-		
-	if (! hThread1) {
+	               NULL,							// Security Descriptor (handle not inheritable)
+	               0,								// initial stack size (default)
+	               reader,						// thread function
+	               NULL,							// thread argument
+	               0,								// creation option (run immediately)
+	               &dwThreadID1				// thread identifier
+	           );
+
+	if (! hThread1)
+	{
 		fprintf(stderr, "Unable to create thread 1.\n");
 		ExitProcess(4);
 	}
 
 	hThread2 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			writer,						// thread function
-			NULL,							// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID2				// thread identifier
-	);
+	               NULL,							// Security Descriptor (handle not inheritable)
+	               0,								// initial stack size (default)
+	               writer,						// thread function
+	               NULL,							// thread argument
+	               0,								// creation option (run immediately)
+	               &dwThreadID2				// thread identifier
+	           );
 
-	if (! hThread2) {
+	if (! hThread2)
+	{
 		fprintf(stderr, "Unable to create thread 2.\n");
 		ExitProcess(5);
 	}
 
 	/* the main program (i.e. the heavyweight parent process) waits
 	 * for the threads to finish.
-	 */ 
+	 */
 	WaitForSingleObject(hThread1, INFINITE);
 	WaitForSingleObject(hThread2, INFINITE);
-	
+
 	fclose(src);
 	fclose(dst);
-	
+
 	ExitProcess(0);
 }
 
-  
 
-/* 
- * reader(): The function reader() is the entire reader thread. It 
+
+/*
+ * reader(): The function reader() is the entire reader thread. It
  * synchronizes with the writer thread, which execute the writer() function.
- */ 
+ */
 DWORD WINAPI reader(LPVOID arg)
 {
 	printf("Reader thread, file = %d\n", src->_file);
 	fflush(stdout);
 
-	while (1) {
-		if (flag == READ) {  
+	while (1)
+	{
+		if (flag == READ)
+		{
 			in = fread(
-					buf,			// Storage location for data
-					1,				// Item size in bytes
-					bufsize,		// Maximum number of items to be read
-					src			// Pointer to FILE structure
-			);
-#ifdef DEBUG			
+			         buf,			// Storage location for data
+			         1,				// Item size in bytes
+			         bufsize,		// Maximum number of items to be read
+			         src			// Pointer to FILE structure
+			     );
+#ifdef DEBUG
 			printf("read %d character\n", in);
 #endif
 			fflush(stdout);
 			flag = WRITE;
-			if (0 == in) 
+			if (0 == in)
 				break;
-		}	   
+		}
 	}
 	ExitThread(0);
 }
@@ -129,30 +135,32 @@ DWORD WINAPI reader(LPVOID arg)
 
 
 /*
- * 
+ *
  * writer(): The main function for the writer thread.
- */ 
-DWORD WINAPI writer(LPVOID arg) 
+ */
+DWORD WINAPI writer(LPVOID arg)
 {
 	printf("Writer thread, file = %d\n",dst->_file);
 	fflush(stdout);
-	
-	while (1) {
-		if (flag == WRITE) {
+
+	while (1)
+	{
+		if (flag == WRITE)
+		{
 			out = fwrite(
-						buf,		// Pointer to data to be written
-						1,			// Item size in bytes
-						in,		// Maximum number of items to be written
-						dst		// Pointer to FILE structure
-			);
-#ifdef DEBUG			
+			          buf,		// Pointer to data to be written
+			          1,			// Item size in bytes
+			          in,		// Maximum number of items to be written
+			          dst		// Pointer to FILE structure
+			      );
+#ifdef DEBUG
 			printf("wrote %d character\n", out);
 #endif
 			fflush(stdout);
 			flag = READ;
-			if (0 == out) 
+			if (0 == out)
 				break;
-		}   
+		}
 	}
 	ExitThread(0);
 }

--- a/ms-windows/threads/thread-ex.c
+++ b/ms-windows/threads/thread-ex.c
@@ -3,51 +3,54 @@
 
 
 DWORD WINAPI Run(LPVOID threadData);
-  
+
 void main(int argc, char *argv[])
 {
 	LPHANDLE hMerlot, hPinot, hCabernet;
 	DWORD dwThreadIdMerlot, dwThreadIdPinot, dwThreadIdCabernet;
 	DWORD dwExitStatus;
-	
+
 	hMerlot = CreateThread(
-			NULL,						// Security Descriptor (handle not inheritable)
-			0,							// initial stack size (default)
-			Run,						// thread function
-			"merlot",				// thread argument
-			0,							// creation option (run immediately)
-			&dwThreadIdMerlot		// thread identifier
-	);
-		
-	if (! hMerlot) {
+	              NULL,						// Security Descriptor (handle not inheritable)
+	              0,							// initial stack size (default)
+	              Run,						// thread function
+	              "merlot",				// thread argument
+	              0,							// creation option (run immediately)
+	              &dwThreadIdMerlot		// thread identifier
+	          );
+
+	if (! hMerlot)
+	{
 		fprintf(stderr, "Unable to create thread Merlot.\n");
 		ExitProcess(1);
 	}
 
 	hPinot = CreateThread(
-			NULL,						// Security Descriptor (handle not inheritable)
-			0,							// initial stack size (default)
-			Run,						// thread function
-			"pinot",					// thread argument
-			0,							// creation option (run immediately)
-			&dwThreadIdPinot		// thread identifier
-	);
-		
-	if (! hPinot) {
+	             NULL,						// Security Descriptor (handle not inheritable)
+	             0,							// initial stack size (default)
+	             Run,						// thread function
+	             "pinot",					// thread argument
+	             0,							// creation option (run immediately)
+	             &dwThreadIdPinot		// thread identifier
+	         );
+
+	if (! hPinot)
+	{
 		fprintf(stderr, "Unable to create thread Pinot.\n");
 		ExitProcess(1);
 	}
 
 	hCabernet = CreateThread(
-			NULL,						// Security Descriptor (handle not inheritable)
-			0,							// initial stack size (default)
-			Run,						// thread function
-			"cabernet",				// thread argument
-			0,							// creation option (run immediately)
-			&dwThreadIdCabernet		// thread identifier
-	);
-		
-	if (! hCabernet) {
+	                NULL,						// Security Descriptor (handle not inheritable)
+	                0,							// initial stack size (default)
+	                Run,						// thread function
+	                "cabernet",				// thread argument
+	                0,							// creation option (run immediately)
+	                &dwThreadIdCabernet		// thread identifier
+	            );
+
+	if (! hCabernet)
+	{
 		fprintf(stderr, "Unable to create thread Cabernet.\n");
 		ExitProcess(1);
 	}
@@ -60,14 +63,16 @@ void main(int argc, char *argv[])
 	ExitProcess(0);
 }
 
-  
-DWORD WINAPI Run(LPVOID threadData) {
+
+DWORD WINAPI Run(LPVOID threadData)
+{
 	char *szName = (char *)threadData;
 	int i;
-	
-	for (i=0; i<10; i++) {
+
+	for (i=0; i<10; i++)
+	{
 		printf("This is the %s thread\n", szName);
 	}
-	
+
 	ExitThread(0);
 }

--- a/ms-windows/threads/thread-hello-world.c
+++ b/ms-windows/threads/thread-hello-world.c
@@ -1,37 +1,37 @@
 #include <windows.h>
 #include <stdio.h>
 
-DWORD WINAPI PrintMessageFunction( LPVOID ptr ); 
-  
+DWORD WINAPI PrintMessageFunction( LPVOID ptr );
+
 int  main()
 {
 	LPHANDLE phThread1, phThread2;
 	DWORD dwThreadID1, dwThreadID2;
 	char *szMessage1 = "Goodbye";
 	char *szMessage2 = "World";
-	
+
 	phThread1 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			PrintMessageFunction,	// thread function
-			szMessage1,					// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID1				// thread identifier
-	);
+	                NULL,							// Security Descriptor (handle not inheritable)
+	                0,								// initial stack size (default)
+	                PrintMessageFunction,	// thread function
+	                szMessage1,					// thread argument
+	                0,								// creation option (run immediately)
+	                &dwThreadID1				// thread identifier
+	            );
 
 	phThread2 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			PrintMessageFunction,	// thread function
-			szMessage2,					// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID2				// thread identifier
-	);
-		
+	                NULL,							// Security Descriptor (handle not inheritable)
+	                0,								// initial stack size (default)
+	                PrintMessageFunction,	// thread function
+	                szMessage2,					// thread argument
+	                0,								// creation option (run immediately)
+	                &dwThreadID2				// thread identifier
+	            );
+
 
 	ExitProcess(0);
 }
-  
+
 DWORD WINAPI PrintMessageFunction( LPVOID ptr )
 {
 	char *szMessage;

--- a/ms-windows/threads/thread-scheduling.c
+++ b/ms-windows/threads/thread-scheduling.c
@@ -1,7 +1,7 @@
 /*
  * Creates three threads that compute for a long time. Good way
  * to check how threads are scheduled on a manycore machine.
- * 
+ *
 */
 
 #include <windows.h>
@@ -14,35 +14,35 @@ int main()
 	LPHANDLE phThread1, phThread2, phThread3;
 	DWORD dwThreadID1, dwThreadID2, dwThreadID3;
 	DWORD WINAPI ComputeUntilHellAlmostFreezes(LPVOID);
-	
+
 	phThread1 = CreateThread(
-			NULL,								// Security Descriptor (handle not inheritable)
-			0,									// initial stack size (default)
-			ComputeUntilHellAlmostFreezes,	// thread function
-			NULL,								// thread argument
-			0,									// creation option (run immediately)
-			&dwThreadID1					// thread identifier
-	);
-		
+	                NULL,								// Security Descriptor (handle not inheritable)
+	                0,									// initial stack size (default)
+	                ComputeUntilHellAlmostFreezes,	// thread function
+	                NULL,								// thread argument
+	                0,									// creation option (run immediately)
+	                &dwThreadID1					// thread identifier
+	            );
+
 	phThread2 = CreateThread(
-			NULL,								// Security Descriptor (handle not inheritable)
-			0,									// initial stack size (default)
-			ComputeUntilHellAlmostFreezes,	// thread function
-			NULL,								// thread argument
-			0,									// creation option (run immediately)
-			&dwThreadID2					// thread identifier
-	);
+	                NULL,								// Security Descriptor (handle not inheritable)
+	                0,									// initial stack size (default)
+	                ComputeUntilHellAlmostFreezes,	// thread function
+	                NULL,								// thread argument
+	                0,									// creation option (run immediately)
+	                &dwThreadID2					// thread identifier
+	            );
 
 	phThread3 = CreateThread(
-			NULL,								// Security Descriptor (handle not inheritable)
-			0,									// initial stack size (default)
-			ComputeUntilHellAlmostFreezes,	// thread function
-			NULL,								// thread argument
-			0,									// creation option (run immediately)
-			&dwThreadID3					// thread identifier
-	);
-		
-		
+	                NULL,								// Security Descriptor (handle not inheritable)
+	                0,									// initial stack size (default)
+	                ComputeUntilHellAlmostFreezes,	// thread function
+	                NULL,								// thread argument
+	                0,									// creation option (run immediately)
+	                &dwThreadID3					// thread identifier
+	            );
+
+
 	// Wait for threads to complete before exiting (effectively JOIN on both threads)
 	WaitForSingleObject(phThread1, INFINITE);
 	WaitForSingleObject(phThread2, INFINITE);
@@ -55,11 +55,12 @@ DWORD WINAPI ComputeUntilHellAlmostFreezes(LPVOID arg)
 	int i;
 	double tmp;
 
-	for (i=0; i<90000000; i++) {
+	for (i=0; i<90000000; i++)
+	{
 		tmp = sqrt((double) i);
 		if (i%1000 == 0)
 			printf("I am thread %d\n", GetCurrentThreadId());
 	}
-	
+
 	ExitThread(0);
 }

--- a/ms-windows/threads/thread-test.c
+++ b/ms-windows/threads/thread-test.c
@@ -5,43 +5,47 @@
 DWORD WINAPI Run(LPVOID arg);
 
 #define MAX 20000
-  
+
 int main(int argc, char *argv[])
 {
 	LPHANDLE hThread[MAX];
 	DWORD dwThreadIDs[MAX];
 	int i;
-	
-	for (i=0; i<MAX; i++) {
+
+	for (i=0; i<MAX; i++)
+	{
 		hThread[i] = CreateThread(
-				NULL,						// Security Descriptor (handle not inheritable)
-				0,							// initial stack size (default)
-				Run,						// thread function
-				NULL,						// thread argument
-				0,							// creation option (run immediately)
-				&dwThreadIDs[i]		// thread identifier
-		);
-		if (hThread[i] == NULL) {
+		                 NULL,						// Security Descriptor (handle not inheritable)
+		                 0,							// initial stack size (default)
+		                 Run,						// thread function
+		                 NULL,						// thread argument
+		                 0,							// creation option (run immediately)
+		                 &dwThreadIDs[i]		// thread identifier
+		             );
+		if (hThread[i] == NULL)
+		{
 			printf("Error in creating thread. Bailing out!\n");
 			Sleep(3000);
 			ExitProcess(1);
-		} else {
+		}
+		else
+		{
 			printf("Created thread number %d, id %d\n", i, dwThreadIDs[i]);
 		}
 	}
-		
-	
+
+
 	for (i=0; i<MAX; i++)
 		WaitForSingleObject(hThread[i], INFINITE);
 
 	ExitProcess(0);
 }
 
-DWORD WINAPI Run(LPVOID arg) 
+DWORD WINAPI Run(LPVOID arg)
 {
 	Sleep(10000);
 	printf("This is  thread id = %d\n", GetCurrentThreadId());
-	
-		
+
+
 	ExitThread(0);
 }

--- a/ms-windows/threads/threads-hello-world.c
+++ b/ms-windows/threads/threads-hello-world.c
@@ -1,37 +1,37 @@
 #include <windows.h>
 #include <stdio.h>
 
-DWORD WINAPI PrintMessageFunction( LPVOID ptr ); 
-  
+DWORD WINAPI PrintMessageFunction( LPVOID ptr );
+
 int  main()
 {
 	LPHANDLE phThread1, phThread2;
 	DWORD dwThreadID1, dwThreadID2;
 	char *szMessage1 = "Goodbye";
 	char *szMessage2 = "World";
-	
+
 	phThread1 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			PrintMessageFunction,	// thread function
-			szMessage1,					// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID1				// thread identifier
-	);
+	                NULL,							// Security Descriptor (handle not inheritable)
+	                0,								// initial stack size (default)
+	                PrintMessageFunction,	// thread function
+	                szMessage1,					// thread argument
+	                0,								// creation option (run immediately)
+	                &dwThreadID1				// thread identifier
+	            );
 
 	phThread2 = CreateThread(
-			NULL,							// Security Descriptor (handle not inheritable)
-			0,								// initial stack size (default)
-			PrintMessageFunction,	// thread function
-			szMessage2,					// thread argument
-			0,								// creation option (run immediately)
-			&dwThreadID2				// thread identifier
-	);
-		
+	                NULL,							// Security Descriptor (handle not inheritable)
+	                0,								// initial stack size (default)
+	                PrintMessageFunction,	// thread function
+	                szMessage2,					// thread argument
+	                0,								// creation option (run immediately)
+	                &dwThreadID2				// thread identifier
+	            );
+
 
 	ExitProcess(0);
 }
-  
+
 DWORD WINAPI PrintMessageFunction( LPVOID ptr )
 {
 	char *szMessage;

--- a/pipes-fifos/color.c
+++ b/pipes-fifos/color.c
@@ -1,26 +1,26 @@
 #include <stdio.h>
 #include <stdlib.h>
- 
+
 #define red   "\033[0;31m"        /* 0 -> normal ;  31 -> red */
 #define cyan  "\033[1;36m"        /* 1 -> bold ;  36 -> cyan */
 #define green "\033[4;32m"        /* 4 -> underline ;  32 -> green */
 #define blue  "\033[9;34m"        /* 9 -> strike ;  34 -> blue */
- 
+
 #define black  "\033[0;30m"
 #define brown  "\033[0;33m"
 #define magenta  "\033[0;35m"
 #define gray  "\033[0;37m"
- 
+
 #define none   "\033[0m"        /* to flush the previous property */
- 
+
 int main(void)
 {
 	printf("\n");
 	printf("%sHello, %sworld!%s\n", red, blue, none);
-  	printf("%sHello%s, %sworld!\n", green, none, cyan);
-   	printf("%s", none);
-   	printf("Vanilla hello\n");
+	printf("%sHello%s, %sworld!\n", green, none, cyan);
+	printf("%s", none);
+	printf("Vanilla hello\n");
 	printf("\n");
-	    
-    exit(EXIT_SUCCESS);
+
+	exit(EXIT_SUCCESS);
 }

--- a/pipes-fifos/fifo-client.c
+++ b/pipes-fifos/fifo-client.c
@@ -13,22 +13,25 @@ int main(void)
 	reply = (char *) malloc (sizeof(char)*PIPE_BUF); // PIPE_BUF defined in limits.h
 
 	fifo1 = open("fifo-request", O_WRONLY);
-	if (fifo1 < 0) {
+	if (fifo1 < 0)
+	{
 		perror("fifo-client: cannot open fifo-request");
 		fprintf(stderr, "fifo-client: is the fifo-server running?\n");
 		exit(EXIT_FAILURE);
 	}
 	fifo2 = open("fifo-reply", O_RDONLY);
-	if (fifo2 < 0) {
+	if (fifo2 < 0)
+	{
 		perror("fifo-client: cannot open fifo-reply");
 		fprintf(stderr, "fifo-client: is the fifo-server running?\n");
 		exit(EXIT_FAILURE);
 	}
 
 	count = 0;
-	for (;;) {
+	for (;;)
+	{
 		randvalue = random() % 4;
-		if (randvalue == 0) 
+		if (randvalue == 0)
 			strcpy(request, "I need some money!");
 		else
 			strcpy(request, "Hello parent!");

--- a/pipes-fifos/fifo-server.c
+++ b/pipes-fifos/fifo-server.c
@@ -15,11 +15,13 @@ int main(void)
 	reply = (char *) malloc (sizeof(char)*PIPE_BUF); // PIPE_BUF defined in limits.h
 
 	status = mkfifo("fifo-request", 0600); // read/write by user's processes
-	if (status < 0) {
+	if (status < 0)
+	{
 		perror("hello-fifo");
 	}
 	status = mkfifo("fifo-reply", 0600); // read/write by user's processes
-	if (status < 0) {
+	if (status < 0)
+	{
 		perror("hello-fifo");
 	}
 	signal(SIGINT, cleanup); // call cleanup if user kills us
@@ -29,10 +31,12 @@ int main(void)
 	fifo2 = open("fifo-reply", O_WRONLY);
 
 	count = 0;
-	for (;;) {
+	for (;;)
+	{
 		memset(request, 0, PIPE_BUF);
 		status = read(fifo1, request, PIPE_BUF);
-		if (status == 0)  {
+		if (status == 0)
+		{
 			fprintf(stderr, "parent: server lost the client connection\n");
 			sleep(1); // used for simplicity, there are better ways of doing this!
 			continue;
@@ -40,12 +44,13 @@ int main(void)
 		printf("%schild[%d]: %s\n", red, count, request); // see example color.c for the color stuff
 		if (strstr(request, "money"))
 			strcpy(reply, "Shoo away!"); //safer to use strncpy
-		else 
+		else
 			strcpy(reply, "Hello child!"); //safer to use strncpy
 
 		printf("%sparent[%d]: %s\n", blue, count, reply);
 		status = write(fifo2, reply, strnlen(reply, PIPE_BUF)); //safer to use strnlen
-		if (status == 0)  {
+		if (status == 0)
+		{
 			fprintf(stderr, "parent: server lost the client connection\n");
 			sleep(1); // used for simplicity, there are better ways of doing this!
 			continue;
@@ -61,7 +66,7 @@ int main(void)
 }
 
 
-void cleanup(int signo) 
+void cleanup(int signo)
 {
 	printf("\nfifo-server: cleaning up....\n");
 	unlink("fifo-request");
@@ -74,4 +79,4 @@ void resume(int signo)
 {
 	printf("Caught SIGPIPE!\n");
 }
-	
+

--- a/pipes-fifos/fifo-talk.c
+++ b/pipes-fifos/fifo-talk.c
@@ -13,29 +13,34 @@ int main(void)
 	reply = (char *) malloc (sizeof(char)*PIPE_BUF); // PIPE_BUF defined in limits.h
 
 	status = mkfifo("fifo-request", 0600); // read/write by user's processes
-	if (status < 0) {
+	if (status < 0)
+	{
 		perror("hello-fifo");
 	}
 	status = mkfifo("fifo-reply", 0600); // read/write by user's processes
-	if (status < 0) {
+	if (status < 0)
+	{
 		perror("hello-fifo");
 	}
 
 	if ((pid = fork()) < 0)
 		err_sys("fork error");
 
-	else if (pid > 0) {		/* parent */
+	else if (pid > 0)  		/* parent */
+	{
 		fifo1 = open("fifo-request", O_RDONLY);
 		fifo2 = open("fifo-reply", O_WRONLY);
 		read(fifo1, request, PIPE_BUF);
 		printf("parent read: %s\n", request);
 		if (strstr(request, "money"))
 			strcpy(reply, "Shoo away!");
-		else 
+		else
 			strcpy(reply, "Hello child!");
 		write(fifo2, reply, strlen(reply));
 
-	} else {				/* child */
+	}
+	else  				/* child */
+	{
 		fifo1 = open("fifo-request", O_WRONLY);
 		fifo2 = open("fifo-reply", O_RDONLY);
 		strcpy(request, "I need some money!");

--- a/pipes-fifos/hello-fifo.c
+++ b/pipes-fifos/hello-fifo.c
@@ -14,18 +14,22 @@ int main(void)
 	int status;
 
 	status = mkfifo("fifo1", 0600); // read/write by user's processes
-	if (status < 0) {
+	if (status < 0)
+	{
 		perror("hello-fifo");
 	}
 
 	if ((pid = fork()) < 0)
 		err_sys("fork error");
 
-	else if (pid > 0) {		/* parent */
+	else if (pid > 0)  		/* parent */
+	{
 		fifo = open("fifo1", O_WRONLY);
 		write(fifo, "hello world\n", 12);
 
-	} else {				/* child */
+	}
+	else  				/* child */
+	{
 		fifo = open("fifo1", O_RDONLY);
 		n = read(fifo, line, MAXLINE);
 		printf("child read %d characters from the parent in the pipe: %s", n, line);

--- a/pipes-fifos/hello-pipe.c
+++ b/pipes-fifos/hello-pipe.c
@@ -13,11 +13,14 @@ int main(void)
 	if ((pid = fork()) < 0)
 		err_sys("fork error");
 
-	else if (pid > 0) {		/* parent */
+	else if (pid > 0)  		/* parent */
+	{
 		close(fd[0]); /* close read end of pipe */
 		write(fd[1], "hello world\n", 12);
 
-	} else {				/* child */
+	}
+	else  				/* child */
+	{
 		close(fd[1]); /* close write end of pipe */
 		n = read(fd[0], line, MAXLINE);
 		printf("child read %d characters from the parent in the pipe: %s", n, line);

--- a/pipes-fifos/pipe-talk.c
+++ b/pipes-fifos/pipe-talk.c
@@ -13,27 +13,27 @@ int count = 0;
 char *str1 = "hello child";
 char *str2 = "hello parent";
 char *responses[] = {"Please tell me more.",
-                    "Are you sure?",
-                    "Why do you think that?",
-                    "Why do you feel like that?",
-                    "I am not sure I understand. Please explain again.",
-                    "I hope things will get better for you",
-                    "Can't you be more positive?",
-                    "Are such questions on your mind often?",
-                    "Please don't repeat yourself!",
-                    "Perhaps you don't want to.",
-                    "Why not?",
-                    "Do you dream often?",
-                    "I see.",
-                    "Tell me about your problems.",
-                    "Tell me more.",
-                    "What makes you think like that?",
-                    "Do you often feel like this?",
-                    "It is a pleasure to talk to you.",
-                    "How are you?",
-                    "I am fine.",
-                    "Don't bother me."
-					};
+                     "Are you sure?",
+                     "Why do you think that?",
+                     "Why do you feel like that?",
+                     "I am not sure I understand. Please explain again.",
+                     "I hope things will get better for you",
+                     "Can't you be more positive?",
+                     "Are such questions on your mind often?",
+                     "Please don't repeat yourself!",
+                     "Perhaps you don't want to.",
+                     "Why not?",
+                     "Do you dream often?",
+                     "I see.",
+                     "Tell me about your problems.",
+                     "Tell me more.",
+                     "What makes you think like that?",
+                     "Do you often feel like this?",
+                     "It is a pleasure to talk to you.",
+                     "How are you?",
+                     "I am fine.",
+                     "Don't bother me."
+                    };
 const int RESPONSE_LENGTH = 21;
 const int TALK_LENGTH = 10;
 int	pipe_parent[2], pipe_child[2];
@@ -52,11 +52,14 @@ int main(void)
 	if ((pid = fork()) < 0)
 		err_sys("fork error");
 
-	else if (pid > 0) {		/* parent */
+	else if (pid > 0)  		/* parent */
+	{
 		close(pipe_parent[0]); /* close read end of pipe */
 		close(pipe_child[1]); /* close write end of pipe */
 		do_parent();
-	} else {				/* child */
+	}
+	else  				/* child */
+	{
 		close(pipe_parent[1]); /* close write end of pipe */
 		close(pipe_child[0]); /* close read end of pipe */
 		do_child();
@@ -68,26 +71,32 @@ int main(void)
 /**
  * The parent process for the chat session.
  */
-static void do_parent() 
+static void do_parent()
 {
 	int index, i;
 	srandom(getpid());
-	while (TRUE) {
+	while (TRUE)
+	{
 		sleep(1);
-		if (count == 0) {
+		if (count == 0)
+		{
 			write(pipe_parent[1], str1, strnlen(str1, MAXLINE));
-		} else {
+		}
+		else
+		{
 			index = random() % RESPONSE_LENGTH;
 			write(pipe_parent[1], responses[index] , strnlen(responses[index], MAXLINE));
 		}
 		sleep(1);
 		read(pipe_child[0], line, MAXLINE);
 		printf("%schild[%d]: %s%s\n", blue, count, line, none);
-		if (strcmp(line, "bye") == 0) {
+		if (strcmp(line, "bye") == 0)
+		{
 			break;
 		}
 		count++;
-		if (count == TALK_LENGTH) {
+		if (count == TALK_LENGTH)
+		{
 			printf("parent[%d]: My time is exhausted. Bye.\n", count);
 			break;
 		}
@@ -99,28 +108,34 @@ static void do_parent()
 /**
  * The child process for the chat session.
  */
-static void do_child() 
+static void do_child()
 {
 	int index, i;
 	srandom(getpid());
-	while (TRUE) {
+	while (TRUE)
+	{
 		sleep(1);
 		read(pipe_parent[0], line, MAXLINE);
 		printf("%sparent[%d]: %s%s\n", red, count, line, none);
 		sleep(1);
-		if (strncmp(line, "bye", MAXLINE) == 0) {
+		if (strncmp(line, "bye", MAXLINE) == 0)
+		{
 			break;
 		}
 		count++;
-		if (count == TALK_LENGTH) {
+		if (count == TALK_LENGTH)
+		{
 			printf("child[%d]: My friends are here. Bye.\n", count);
 			write(pipe_child[1], "bye", 4);
 			break;
 		}
 		for (i=0; i<MAXLINE; i++) line[i] = 0;
-		if (count == 0) {
+		if (count == 0)
+		{
 			write(pipe_parent[1], str2, strnlen(str2, MAXLINE));
-		} else {
+		}
+		else
+		{
 			index = random() % RESPONSE_LENGTH;
 			write(pipe_child[1], responses[index], strnlen(responses[index], MAXLINE));
 		}

--- a/plugins/ex1/plugin1.c
+++ b/plugins/ex1/plugin1.c
@@ -13,5 +13,5 @@
 
 void plugin(void)
 {
-  printf("This is plug-in 1\n");
+	printf("This is plug-in 1\n");
 }

--- a/plugins/ex1/plugin2.c
+++ b/plugins/ex1/plugin2.c
@@ -13,6 +13,6 @@
 
 void plugin(void)
 {
-  printf("This is the second plug-in\n");
+	printf("This is the second plug-in\n");
 }
 

--- a/plugins/ex1/runplug.c
+++ b/plugins/ex1/runplug.c
@@ -24,48 +24,48 @@ const char *dlError;    /* error string */
 
 int main(int argc, char **argv)
 {
-  char buf[MAX_BUF];
-  char plugName[MAX_BUF];
+	char buf[MAX_BUF];
+	char plugName[MAX_BUF];
 
-  while (1)
-  {
-    /* get plug-in name */
-    printf("Enter plugin name (exit to exit): ");
-    fgets(buf, MAX_BUF, stdin);
-    buf[strlen(buf)-1] = '\0';       /* change \n to \0 */
-    sprintf(plugName, "./%s", buf);  /* start from current dir */
+	while (1)
+	{
+		/* get plug-in name */
+		printf("Enter plugin name (exit to exit): ");
+		fgets(buf, MAX_BUF, stdin);
+		buf[strlen(buf)-1] = '\0';       /* change \n to \0 */
+		sprintf(plugName, "./%s", buf);  /* start from current dir */
 
-    /* checks for exit */
-    if (!strcmp(plugName, "./exit"))
-      return 0;
+		/* checks for exit */
+		if (!strcmp(plugName, "./exit"))
+			return 0;
 
-    /* open a library */
-    handle = dlopen(plugName, RTLD_LAZY);
-    if ((dlError = dlerror()))
-    {
-      printf("Opening Error: %s\n", dlError);
-      continue;
-    }
+		/* open a library */
+		handle = dlopen(plugName, RTLD_LAZY);
+		if ((dlError = dlerror()))
+		{
+			printf("Opening Error: %s\n", dlError);
+			continue;
+		}
 
-    /* loads the plugin function */
-    function = dlsym( handle, "plugin");
-    if ((dlError = dlerror()))
-      printf("Loading Error: %s\n", dlError);
+		/* loads the plugin function */
+		function = dlsym( handle, "plugin");
+		if ((dlError = dlerror()))
+			printf("Loading Error: %s\n", dlError);
 
-    /* execute the function */
-    (*function)(); /* function() */
-    if ((dlError = dlerror()))
-      printf("Execution Error: %s\n", dlError);
-	/*sleep(10);*/
-    (*function)();
-    if ((dlError = dlerror()))
-      printf("Execution Error: %s\n", dlError);
+		/* execute the function */
+		(*function)(); /* function() */
+		if ((dlError = dlerror()))
+			printf("Execution Error: %s\n", dlError);
+		/*sleep(10);*/
+		(*function)();
+		if ((dlError = dlerror()))
+			printf("Execution Error: %s\n", dlError);
 
-    /* close library 1 */
-    dlclose(handle);
-    if ((dlError = dlerror()))
-      printf("Closing Error: %s\n", dlError);
-  }
+		/* close library 1 */
+		dlclose(handle);
+		if ((dlError = dlerror()))
+			printf("Closing Error: %s\n", dlError);
+	}
 
-  return 0;
+	return 0;
 }

--- a/plugins/ex2/Goodbye.c
+++ b/plugins/ex2/Goodbye.c
@@ -2,10 +2,10 @@
 
 void message1()
 {
-  printf("Goodbye ");
+	printf("Goodbye ");
 }
 
 void message2()
 {
-  printf("Cruel World!\n");
+	printf("Cruel World!\n");
 }

--- a/plugins/ex2/Hello.c
+++ b/plugins/ex2/Hello.c
@@ -2,12 +2,12 @@
 
 void message1()
 {
-  printf("Hello ");
+	printf("Hello ");
 }
 
 void message2()
 {
-  printf("World!\n");
+	printf("World!\n");
 }
 
 

--- a/plugins/ex2/Loader.c
+++ b/plugins/ex2/Loader.c
@@ -5,70 +5,74 @@
 
 int main()
 {
-  fMessage fMsg[NMESSAGES];
-    //  Open the desired libraries.
-  HANDLE hHello   = dlopen("./Hello.so", RTLD_LAZY);
-  HANDLE hGoodbye = dlopen("./Goodbye.so", RTLD_LAZY);
-  HANDLE hWazUp = NULL;
-  /*HANDLE hWazUp   = dlopen("./libHello.dll", RTLD_LAZY);*/
-  int exitcode = 0, i;
+	fMessage fMsg[NMESSAGES];
+	//  Open the desired libraries.
+	HANDLE hHello   = dlopen("./Hello.so", RTLD_LAZY);
+	HANDLE hGoodbye = dlopen("./Goodbye.so", RTLD_LAZY);
+	HANDLE hWazUp = NULL;
+	/*HANDLE hWazUp   = dlopen("./libHello.dll", RTLD_LAZY);*/
+	int exitcode = 0, i;
 
-    //  Check that the libraries opened.
-  if (!hHello || !hGoodbye)
-  {
-    fprintf(stderr, "Open: %s\n", dlerror());
-    exitcode = -1;
-    goto LABEL_EXIT;
-  }
-  if (!hWazUp)
-  {
-    fprintf(stderr, "Windows Dll Open: %s\n", dlerror());
-  }
+	//  Check that the libraries opened.
+	if (!hHello || !hGoodbye)
+	{
+		fprintf(stderr, "Open: %s\n", dlerror());
+		exitcode = -1;
+		goto LABEL_EXIT;
+	}
+	if (!hWazUp)
+	{
+		fprintf(stderr, "Windows Dll Open: %s\n", dlerror());
+	}
 
-    //  Load symbols from libraries.
-  fMsg[0] = (fMessage)dlsym(hHello, "message1");
-  fMsg[1] = (fMessage)dlsym(hHello, "message2");
-  fMsg[2] = (fMessage)dlsym(hGoodbye, "message1");
-  fMsg[3] = (fMessage)dlsym(hGoodbye, "message2");
-  /*sleep(100);*/
-  //  Check that the symbols loaded.
-  for(i = 0; i < NMESSAGES; i++)
-  {
-    if (!fMsg[i])
-    {
-      fprintf(stderr, "Msg%i: %s\n", i, dlerror());
-      exitcode = i;
-      goto LABEL_EXIT;
-    }
-  }
+	//  Load symbols from libraries.
+	fMsg[0] = (fMessage)dlsym(hHello, "message1");
+	fMsg[1] = (fMessage)dlsym(hHello, "message2");
+	fMsg[2] = (fMessage)dlsym(hGoodbye, "message1");
+	fMsg[3] = (fMessage)dlsym(hGoodbye, "message2");
+	/*sleep(100);*/
+	//  Check that the symbols loaded.
+	for(i = 0; i < NMESSAGES; i++)
+	{
+		if (!fMsg[i])
+		{
+			fprintf(stderr, "Msg%i: %s\n", i, dlerror());
+			exitcode = i;
+			goto LABEL_EXIT;
+		}
+	}
 
-    //  Print message pairs.
-  fMsg[0]();  fMsg[1]();  // Hello World!
-  fMsg[2]();  fMsg[3]();  // Goodbye Cruel World!
-  fMsg[0]();  fMsg[3]();  // Hello Cruel World!
-  fMsg[2]();  fMsg[1]();  // Goodbye World!
+	//  Print message pairs.
+	fMsg[0]();
+	fMsg[1]();  // Hello World!
+	fMsg[2]();
+	fMsg[3]();  // Goodbye Cruel World!
+	fMsg[0]();
+	fMsg[3]();  // Hello Cruel World!
+	fMsg[2]();
+	fMsg[1]();  // Goodbye World!
 
-    //  If by some miracle the windows dll loaded, load & call its function.
-  if (hWazUp)
-  {
-    fMessage fWinMsg = (fMessage)dlsym(hWazUp, "message1");
-    if (!fWinMsg)
-    {
-      fprintf(stderr, "WinMsg: %s\n", dlerror());
-      exitcode = 5;
-      goto LABEL_EXIT;
-    }
-    fWinMsg();
-  }
+	//  If by some miracle the windows dll loaded, load & call its function.
+	if (hWazUp)
+	{
+		fMessage fWinMsg = (fMessage)dlsym(hWazUp, "message1");
+		if (!fWinMsg)
+		{
+			fprintf(stderr, "WinMsg: %s\n", dlerror());
+			exitcode = 5;
+			goto LABEL_EXIT;
+		}
+		fWinMsg();
+	}
 
 LABEL_EXIT:
-    //  clean up the library handles.
-  if (hHello)
-    dlclose(hHello);
-  if (hGoodbye)
-    dlclose(hGoodbye);
-  if (hWazUp)
-    dlclose(hWazUp);
+	//  clean up the library handles.
+	if (hHello)
+		dlclose(hHello);
+	if (hGoodbye)
+		dlclose(hGoodbye);
+	if (hWazUp)
+		dlclose(hWazUp);
 
-  return exitcode;
+	return exitcode;
 }

--- a/plugins/ex2/libHello.c
+++ b/plugins/ex2/libHello.c
@@ -2,10 +2,10 @@
 
 void message1()
 {
-     printf("What's up doc?");
+	printf("What's up doc?");
 }
 
 void message2()
 {
-     printf("\n");
+	printf("\n");
 }

--- a/plugins/ex3/Goodbye.c
+++ b/plugins/ex3/Goodbye.c
@@ -2,10 +2,10 @@
 
 void message1()
 {
-  printf("Goodbye ");
+	printf("Goodbye ");
 }
 
 void message2()
 {
-  printf("Cruel World!\n");
+	printf("Cruel World!\n");
 }

--- a/plugins/ex3/Hello.c
+++ b/plugins/ex3/Hello.c
@@ -4,13 +4,13 @@ int x;
 
 void message1()
 {
-  x++;
-  printf("Hello %d ", x);
+	x++;
+	printf("Hello %d ", x);
 }
 
 void message2()
 {
-  printf("World!\n");
+	printf("World!\n");
 }
 
 

--- a/plugins/ex3/Loader.c
+++ b/plugins/ex3/Loader.c
@@ -4,48 +4,53 @@
 
 int main()
 {
-  fMessage fMsg[NMESSAGES];
-  //  Open the desired libraries.
-  HANDLE hHello   = dlopen("./Hello.so", RTLD_LAZY);
-  HANDLE temp   = dlopen("./temp.so", RTLD_LAZY);
-  HANDLE hGoodbye = dlopen("./Goodbye.so", RTLD_LAZY);
-  int exitcode = 0, i;
+	fMessage fMsg[NMESSAGES];
+	//  Open the desired libraries.
+	HANDLE hHello   = dlopen("./Hello.so", RTLD_LAZY);
+	HANDLE temp   = dlopen("./temp.so", RTLD_LAZY);
+	HANDLE hGoodbye = dlopen("./Goodbye.so", RTLD_LAZY);
+	int exitcode = 0, i;
 
-  //  Check that the libraries opened.
-  if (!hHello || !hGoodbye) {
-    fprintf(stderr, "Open: %s\n", dlerror());
-    exitcode = -1;
-    goto LABEL_EXIT;
-  }
+	//  Check that the libraries opened.
+	if (!hHello || !hGoodbye)
+	{
+		fprintf(stderr, "Open: %s\n", dlerror());
+		exitcode = -1;
+		goto LABEL_EXIT;
+	}
 
-  printf("handle for Hello lib = %x,  handle for second hello lib %x \n", hHello, temp);
+	printf("handle for Hello lib = %x,  handle for second hello lib %x \n", hHello, temp);
 
-  //  Load symbols from libraries.
-  fMsg[0] = (fMessage)dlsym(hHello, "message1");
-  fMsg[1] = (fMessage)dlsym(hHello, "message2");
-  fMsg[2] = (fMessage)dlsym(temp, "message1");
-  fMsg[3] = (fMessage)dlsym(temp, "message2");
+	//  Load symbols from libraries.
+	fMsg[0] = (fMessage)dlsym(hHello, "message1");
+	fMsg[1] = (fMessage)dlsym(hHello, "message2");
+	fMsg[2] = (fMessage)dlsym(temp, "message1");
+	fMsg[3] = (fMessage)dlsym(temp, "message2");
 
-  //  Check that the symbols loaded.
-  for(i = 0; i < NMESSAGES; i++) {
-    if (!fMsg[i]) {
-      fprintf(stderr, "Msg%i: %s\n", i, dlerror());
-      exitcode = i;
-      goto LABEL_EXIT;
-    }
-  }
+	//  Check that the symbols loaded.
+	for(i = 0; i < NMESSAGES; i++)
+	{
+		if (!fMsg[i])
+		{
+			fprintf(stderr, "Msg%i: %s\n", i, dlerror());
+			exitcode = i;
+			goto LABEL_EXIT;
+		}
+	}
 
-  //  Print message pairs.
-  fMsg[0]();  fMsg[1]();  // Hello World!
-  fMsg[2]();  fMsg[3]();  // Hello World again from the second copy of the library
+	//  Print message pairs.
+	fMsg[0]();
+	fMsg[1]();  // Hello World!
+	fMsg[2]();
+	fMsg[3]();  // Hello World again from the second copy of the library
 
 
 LABEL_EXIT:
-    //  clean up the library handles.
-  if (hHello)
-    dlclose(hHello);
-  if (hGoodbye)
-    dlclose(hGoodbye);
+	//  clean up the library handles.
+	if (hHello)
+		dlclose(hHello);
+	if (hGoodbye)
+		dlclose(hGoodbye);
 
-  return exitcode;
+	return exitcode;
 }

--- a/plugins/ex4/Hello.c
+++ b/plugins/ex4/Hello.c
@@ -1,9 +1,9 @@
 /* Hello.c
- * Modified by Marissa Hollingsworth to demonstrate independent 
- * thread access of global variables when each thread loads a 
+ * Modified by Marissa Hollingsworth to demonstrate independent
+ * thread access of global variables when each thread loads a
  * copy of the same library.
  *
- * The global variable x is modified with calls to message2() 
+ * The global variable x is modified with calls to message2()
  * and message3().
  */
 
@@ -14,20 +14,20 @@ int x = 1;
 
 void message1()
 {
- printf("[%X] Hello World! \n", pthread_self());
+	printf("[%X] Hello World! \n", pthread_self());
 }
 
 /* message2 and 3 demonstrate that */
 void message2()
 {
-  printf("[%X] I can count to three!! %d", pthread_self(),x);
-  x++;
-  printf(" %d\n", x); 
+	printf("[%X] I can count to three!! %d", pthread_self(),x);
+	x++;
+	printf(" %d\n", x);
 }
 
 void message3()
 {
-  x++;
-  printf("[%X] and %d!!\n", pthread_self(),x);
+	x++;
+	printf("[%X] and %d!!\n", pthread_self(),x);
 }
 

--- a/plugins/ex4/Loader.c
+++ b/plugins/ex4/Loader.c
@@ -7,64 +7,67 @@ void *load_library(void *);
 
 int main()
 {
-  char *hHello = "./Hello.so";
-  char *hCopyOfHello = "./CopyOfHello.so";
+	char *hHello = "./Hello.so";
+	char *hCopyOfHello = "./CopyOfHello.so";
 
-  /* Create threads with with different library references. */
-  pthread_t tHello, tCopyOfHello;
-  pthread_create(&tHello, NULL, load_library, (void*) hHello);
-  pthread_create(&tCopyOfHello, NULL, load_library, (void*) hCopyOfHello);
+	/* Create threads with with different library references. */
+	pthread_t tHello, tCopyOfHello;
+	pthread_create(&tHello, NULL, load_library, (void*) hHello);
+	pthread_create(&tCopyOfHello, NULL, load_library, (void*) hCopyOfHello);
 
-  pthread_join(tHello, NULL);
-  pthread_join(tCopyOfHello, NULL);
+	pthread_join(tHello, NULL);
+	pthread_join(tCopyOfHello, NULL);
 }
 
-void* load_library(void *libRef) 
+void* load_library(void *libRef)
 {
-  int exitcode = 0, i;
-  fMessage fMsg[NMESSAGES];
+	int exitcode = 0, i;
+	fMessage fMsg[NMESSAGES];
 
-  /* Open the desired library. */
-  HANDLE hHello = dlopen(libRef, RTLD_LAZY);
+	/* Open the desired library. */
+	HANDLE hHello = dlopen(libRef, RTLD_LAZY);
 
-  /* Check that the library opened. */
-  if (!hHello) {
-    fprintf(stderr, "[%X] Open: %s\n",pthread_self(), dlerror());
-    exitcode = -1;
-    goto LABEL_EXIT;
-  }
+	/* Check that the library opened. */
+	if (!hHello)
+	{
+		fprintf(stderr, "[%X] Open: %s\n",pthread_self(), dlerror());
+		exitcode = -1;
+		goto LABEL_EXIT;
+	}
 
-  /* Announce self and library pointer*/
-  printf("threadId:%X libraryPtr:%x \n", pthread_self(), hHello);
+	/* Announce self and library pointer*/
+	printf("threadId:%X libraryPtr:%x \n", pthread_self(), hHello);
 
-  /* Load symbols from library. */
-  fMsg[0] = (fMessage)dlsym(hHello, "message1");
-  fMsg[1] = (fMessage)dlsym(hHello, "message2");
-  fMsg[2] = (fMessage)dlsym(hHello, "message3");
+	/* Load symbols from library. */
+	fMsg[0] = (fMessage)dlsym(hHello, "message1");
+	fMsg[1] = (fMessage)dlsym(hHello, "message2");
+	fMsg[2] = (fMessage)dlsym(hHello, "message3");
 
-  /* Check that the symbols loaded. */
-  for(i = 0; i < NMESSAGES; i++) {
-    if (!fMsg[i]) {
-      fprintf(stderr, "[%X] Msg%i: %s\n",pthread_self(), i, dlerror());
-      exitcode = i;
-      goto LABEL_EXIT;
-    }
-  }
+	/* Check that the symbols loaded. */
+	for(i = 0; i < NMESSAGES; i++)
+	{
+		if (!fMsg[i])
+		{
+			fprintf(stderr, "[%X] Msg%i: %s\n",pthread_self(), i, dlerror());
+			exitcode = i;
+			goto LABEL_EXIT;
+		}
+	}
 
-  /* Print message pointers. */
-  printf("[%X] message1 ptr: %x\n", pthread_self(), &fMsg[0]);
-  printf("[%X] message2 ptr: %x\n", pthread_self(), &fMsg[1]);
-  printf("[%X] message3 ptr: %x\n", pthread_self(), &fMsg[2]);
-  
-  /* Print messages*/
-  fMsg[0]();  // Hello World!
-  fMsg[1]();  // I can count to three! 1 2
-  fMsg[2]();  // and 3!!
+	/* Print message pointers. */
+	printf("[%X] message1 ptr: %x\n", pthread_self(), &fMsg[0]);
+	printf("[%X] message2 ptr: %x\n", pthread_self(), &fMsg[1]);
+	printf("[%X] message3 ptr: %x\n", pthread_self(), &fMsg[2]);
+
+	/* Print messages*/
+	fMsg[0]();  // Hello World!
+	fMsg[1]();  // I can count to three! 1 2
+	fMsg[2]();  // and 3!!
 
 LABEL_EXIT:
-  /* clean up the library handle. */
-  if (hHello)
-    dlclose(hHello);
+	/* clean up the library handle. */
+	if (hHello)
+		dlclose(hHello);
 
-  pthread_exit(NULL);
+	pthread_exit(NULL);
 }

--- a/sandbox/list_stuff/list.c
+++ b/sandbox/list_stuff/list.c
@@ -1,7 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-struct node {
+struct node
+{
 	struct node *next;
 	int data;
 };
@@ -40,7 +41,8 @@ int main (int foo, char *bar[])
 	//Pointer to use for moving through the list
 	struct node *curr = head;
 	//for loop using C99 syntax
-	for(int i =0;i<10;i++){
+	for(int i =0; i<10; i++)
+	{
 		//(*curr).next = createNode(i);
 		curr->next = createNode(i);
 		//go to the next node in the list;
@@ -48,7 +50,8 @@ int main (int foo, char *bar[])
 	}
 	//Reset curr so we can go through the list
 	curr = head;
-	while(curr){
+	while(curr)
+	{
 		printNode(curr);
 		curr = curr->next;
 	}

--- a/sandbox/list_stuff/listg.c
+++ b/sandbox/list_stuff/listg.c
@@ -1,24 +1,26 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-struct point {
-    int x;
-    int r;
+struct point
+{
+	int x;
+	int r;
 };
 
 char *toString(void *foo)
 {
-    char *tmp = malloc(6);
-    struct point *p = (struct point *) foo;
-    sprintf(tmp, "(%d,%d)", p->x, p->r);
-    return tmp;
+	char *tmp = malloc(6);
+	struct point *p = (struct point *) foo;
+	sprintf(tmp, "(%d,%d)", p->x, p->r);
+	return tmp;
 }
 
 
-struct node {
-    struct node *next;
-    void *data;
-    char *(*toString) (void *);
+struct node
+{
+	struct node *next;
+	void *data;
+	char *(*toString) (void *);
 };
 
 
@@ -29,14 +31,14 @@ struct node {
  */
 void printNode(struct node *n)
 {
-    char *tmp = NULL;
-    if (n)
-	tmp = n->toString(n->data);
-    if (tmp)
-	printf(tmp);
-    else
-	printf("Ack! we are in trouble\n");
-    free(tmp);
+	char *tmp = NULL;
+	if (n)
+		tmp = n->toString(n->data);
+	if (tmp)
+		printf(tmp);
+	else
+		printf("Ack! we are in trouble\n");
+	free(tmp);
 
 }
 
@@ -50,30 +52,32 @@ void printNode(struct node *n)
  */
 struct node *createNode(void *data)
 {
-    struct node *tmp = malloc(sizeof(struct node));
-    tmp->data = data;
-    tmp->next = NULL;
-    return tmp;
+	struct node *tmp = malloc(sizeof(struct node));
+	tmp->data = data;
+	tmp->next = NULL;
+	return tmp;
 }
 
 int main(int foo, char *bar[])
 {
-    //Create a node to represent the "head" of the list
-    struct node *head;		// = createNode(-1);
-    //Pointer to use for moving through the list
-    struct node *curr = head;
-    //for loop using C99 syntax
-    for (int i = 0; i < 10; i++) {
-	//(*curr).next = createNode(i);
-	curr->next = NULL;	// createNode(i);
-	//go to the next node in the list;
-	curr = curr->next;
-    }
-    //Reset curr so we can go through the list
-    curr = head;
-    while (curr) {
-	printNode(curr);
-	curr = curr->next;
-    }
-    return 0;
+	//Create a node to represent the "head" of the list
+	struct node *head;		// = createNode(-1);
+	//Pointer to use for moving through the list
+	struct node *curr = head;
+	//for loop using C99 syntax
+	for (int i = 0; i < 10; i++)
+	{
+		//(*curr).next = createNode(i);
+		curr->next = NULL;	// createNode(i);
+		//go to the next node in the list;
+		curr = curr->next;
+	}
+	//Reset curr so we can go through the list
+	curr = head;
+	while (curr)
+	{
+		printNode(curr);
+		curr = curr->next;
+	}
+	return 0;
 }

--- a/sandbox/marissa/c-generic/List.c
+++ b/sandbox/marissa/c-generic/List.c
@@ -4,8 +4,8 @@
  * Constructor
  */
 struct list *createList(int (*equals)(const void *, const void *),
-		char *(*toString)(const void *),
-		void (*freeObject)(const void *))
+                        char *(*toString)(const void *),
+                        void (*freeObject)(const void *))
 {
 	struct list *list = (struct list *) malloc(sizeof(struct list));
 	list->size = 0;
@@ -45,9 +45,12 @@ void addAtFront(struct list *list, struct node* node)
 	if(list == NULL) return;
 	if(node == NULL) return;
 
-	if(list->head == NULL) {           // case 1. list is currently empty.
+	if(list->head == NULL)             // case 1. list is currently empty.
+	{
 		list->head = node;
-	} else {                           // case 2. it's not empty.
+	}
+	else                               // case 2. it's not empty.
+	{
 		node->next = list->head;
 		list->head = node;
 	}
@@ -85,7 +88,8 @@ struct node* searchList(struct list* list, void *object)
 	while(node != NULL)
 	{
 		// check for equality.
-		if((*list->equals)(node->object,object)) {
+		if((*list->equals)(node->object,object))
+		{
 			return node;
 		}
 		node = node->next;

--- a/sandbox/marissa/c-generic/SimpleTestList.c
+++ b/sandbox/marissa/c-generic/SimpleTestList.c
@@ -1,8 +1,8 @@
 #include "List.h"
 #include "Object.h" // We want to include the object header in the test
-                    // file, NOT Node.h as we had in our previous version.
-		    // We want to completely decouple our object from our
-		    // list implementation.
+// file, NOT Node.h as we had in our previous version.
+// We want to completely decouple our object from our
+// list implementation.
 
 int main(int argc, char *argv[])
 {
@@ -12,7 +12,8 @@ int main(int argc, char *argv[])
 
 	// Add nodes to the list.
 	int i;
-	for(i = 0; i < 10; i++) {
+	for(i = 0; i < 10; i++)
+	{
 		struct object *object = createObject(i, "");
 		node = createNode(object);
 		addAtFront(list, node); //modify to add node instead.
@@ -22,7 +23,7 @@ int main(int argc, char *argv[])
 
 	/* struct node *remove = removeFront(list); */
 	/* remove->next->next = NULL; */
-        /*  */
+	/*  */
 	/* printList(list); */
 
 	freeList(list);

--- a/sandbox/marissa/c-generic/SimpleTestListTwo.c
+++ b/sandbox/marissa/c-generic/SimpleTestListTwo.c
@@ -1,8 +1,8 @@
 #include "List.h"
 #include "Dog.h" // We want to include the dog header in the test
-                    // file, NOT Node.h as we had in our previous version.
-		    // We want to completely decouple our dog from our
-		    // list implementation.
+// file, NOT Node.h as we had in our previous version.
+// We want to completely decouple our dog from our
+// list implementation.
 
 int main(int argc, char *argv[])
 {
@@ -12,7 +12,8 @@ int main(int argc, char *argv[])
 
 	// Add nodes to the list.
 	int i;
-	for(i = 0; i < 10; i++) {
+	for(i = 0; i < 10; i++)
+	{
 		struct dog *dog = createDog(i, "fido");
 		node = createNode(dog);
 		addAtFront(list, node); //modify to add node instead.
@@ -22,7 +23,7 @@ int main(int argc, char *argv[])
 
 	/* struct node *remove = removeFront(list); */
 	/* remove->next->next = NULL; */
-        /*  */
+	/*  */
 	/* printList(list); */
 
 	freeList(list);

--- a/sandbox/marissa/c-generic/UnitTestList.c
+++ b/sandbox/marissa/c-generic/UnitTestList.c
@@ -32,9 +32,12 @@ void printTestInfo(char* testName, char *info)
 
 void printTestResult(char* testName, int passed)
 {
-	if(passed){
+	if(passed)
+	{
 		fprintf(stdout, "%s - %s\n\n", "[PASSED]", testName);
-	}else{
+	}
+	else
+	{
 		fprintf(stdout, "%s - %s\n\n", "[FAILED]", testName);
 	}
 }

--- a/sandbox/marissa/files/parse-file.c
+++ b/sandbox/marissa/files/parse-file.c
@@ -63,5 +63,5 @@ int main(int argc, char *argv[])
 
 
 
-    return 0;
+	return 0;
 }

--- a/shell-scripts/returnval.c
+++ b/shell-scripts/returnval.c
@@ -2,6 +2,6 @@
 
 int main(int argc, char** argv)
 {
-    if(argc != 2) return 0;
-    return atoi(argv[1]);
+	if(argc != 2) return 0;
+	return atoi(argv[1]);
 }

--- a/threads/bad-bank-balance.c
+++ b/threads/bad-bank-balance.c
@@ -11,7 +11,8 @@
 #include <pthread.h>
 
 typedef struct account account;
-struct account {
+struct account
+{
 	double balance;
 };
 account *myacct;
@@ -25,14 +26,16 @@ int main(int argc, char **argv)
 {
 	int i;
 
-	if (argc < 2) {
+	if (argc < 2)
+	{
 		fprintf(stderr, "Usage: %s <numThreads> <iterations>\n", argv[0]);
 		exit(1);
 	}
 
 	numThreads  = atoi(argv[1]);
 	count = atoi(argv[2]);
-	if (numThreads > 32) {
+	if (numThreads > 32)
+	{
 		fprintf(stderr, "Usage: %s Too many threads  specified. Defaulting to 32.\n", argv[0]);
 		numThreads = 32;
 	}
@@ -42,15 +45,15 @@ int main(int argc, char **argv)
 	printf("initial balance = %lf\n", myacct->balance);
 
 
-    tids = (pthread_t *) malloc(sizeof(pthread_t)*numThreads);
-    for (i=0; i<numThreads; i++)
-        pthread_create(&tids[i], NULL, threadMain, (void *) NULL);
+	tids = (pthread_t *) malloc(sizeof(pthread_t)*numThreads);
+	for (i=0; i<numThreads; i++)
+		pthread_create(&tids[i], NULL, threadMain, (void *) NULL);
 
-    for (i=0; i<numThreads; i++)
-        pthread_join(tids[i], NULL);
+	for (i=0; i<numThreads; i++)
+		pthread_join(tids[i], NULL);
 
 	printf("final balance = %lf\n", myacct->balance);
-    exit(0);
+	exit(0);
 }
 
 void *threadMain(void *arg)
@@ -58,7 +61,8 @@ void *threadMain(void *arg)
 	int i;
 	int amount;
 
-	for (i=0; i<count; i++) {
+	for (i=0; i<count; i++)
+	{
 		amount = 1;
 		myacct->balance += amount;
 	}

--- a/threads/prime.c
+++ b/threads/prime.c
@@ -7,11 +7,13 @@
 #define FALSE 0
 
 
-int prime(long long x) {
+int prime(long long x)
+{
 	long long i;
 	long long sqrtx = ceil(sqrt(x));
 
-	for (i = 2; i < sqrtx; i++) {
+	for (i = 2; i < sqrtx; i++)
+	{
 		if (x % i == 0)
 			return FALSE;
 	}
@@ -19,14 +21,16 @@ int prime(long long x) {
 }
 
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 
 	long long n;
 	long long sqrtn;
 	long long i;
 
 
-	if (argc != 2) {
+	if (argc != 2)
+	{
 		fprintf(stderr, "Usage: %s <n>\n", argv[0]);
 		exit(EXIT_FAILURE);
 	}
@@ -36,16 +40,19 @@ int main(int argc, char **argv) {
 	printf("sqrtn = %lld\n", sqrtn);
 
 	printf("\n prime factors of %lld = ", n);
-	for (i = 2; i < sqrtn; i++) {
-		if (prime(i)) {
-			while (n % i == 0)  {
+	for (i = 2; i < sqrtn; i++)
+	{
+		if (prime(i))
+		{
+			while (n % i == 0)
+			{
 				printf(" %lld ", i);
 				n = n/i;
 			}
 			if (n == 1) break;
 		}
 	}
-	if (n > 1) 
+	if (n > 1)
 		printf(" %lld ", n);
 	printf("\n");
 

--- a/threads/random_r.c
+++ b/threads/random_r.c
@@ -7,32 +7,33 @@
 void* random_printer(void *ptr);
 int  main()
 {
-     pthread_t thread1, thread2;
-     pthread_create(&thread1, NULL, random_printer,(void*)1);
-     pthread_create(&thread2, NULL, random_printer, (void*)2);
-     pthread_join(thread1, NULL);
-     pthread_join(thread2, NULL);
-     exit(0);
+	pthread_t thread1, thread2;
+	pthread_create(&thread1, NULL, random_printer,(void*)1);
+	pthread_create(&thread2, NULL, random_printer, (void*)2);
+	pthread_join(thread1, NULL);
+	pthread_join(thread2, NULL);
+	exit(0);
 }
 
 void* random_printer(void *ptr)
 {
-    //get the seed that was passed into the thread
-    int seed = (size_t)ptr;
-    //create our random_data buff on the stack
-    struct random_data buff = {};
-    //create a place to store the result from random_r on the stack
-    int32_t result =0;
-    //create our statebuff for initState_r. Note: that statebuff must not be less than 8 bytes
-    char statebuf[STATE_LEN];
-    //init our state for random_r
-    initstate_r(seed,statebuf,STATE_LEN,&buff);
-    printf("%p\n",&buff);
-    int i;
-    for(i=0;i<10000;i++ ){
-        //get our random numbers.
-        random_r(&buff,&result);
-        printf("%d\n",result);
-    }
-    pthread_exit(NULL);
+	//get the seed that was passed into the thread
+	int seed = (size_t)ptr;
+	//create our random_data buff on the stack
+	struct random_data buff = {};
+	//create a place to store the result from random_r on the stack
+	int32_t result =0;
+	//create our statebuff for initState_r. Note: that statebuff must not be less than 8 bytes
+	char statebuf[STATE_LEN];
+	//init our state for random_r
+	initstate_r(seed,statebuf,STATE_LEN,&buff);
+	printf("%p\n",&buff);
+	int i;
+	for(i=0; i<10000; i++ )
+	{
+		//get our random numbers.
+		random_r(&buff,&result);
+		printf("%d\n",result);
+	}
+	pthread_exit(NULL);
 }

--- a/threads/safe-bank-balance-starvation.c
+++ b/threads/safe-bank-balance-starvation.c
@@ -63,22 +63,27 @@ int main(int argc, char **argv)
 	int i;
 	int *value;
 
-	if (argc < 3) {
+	if (argc < 3)
+	{
 		fprintf(stderr, "Usage: %s <numThreads (1-3)> <good|bad>\n", argv[0]);
 		exit(1);
 	}
 
 	numThreads = atoi(argv[1]);
-	if (numThreads > 3) {
+	if (numThreads > 3)
+	{
 		fprintf(stderr, "Usage: %s Too many threads  specified. Defaulting to 3.\n", argv[0]);
 		numThreads = 3;
 	}
 
 	char *goodArg = argv[2];
-	if(strcmp(goodArg, "good") == 0) {
+	if(strcmp(goodArg, "good") == 0)
+	{
 		good = 1;
 		printf("Running good version...\n");
-	} else {
+	}
+	else
+	{
 		good = 0;
 		printf("Running bad version...\n");
 	}
@@ -89,14 +94,16 @@ int main(int argc, char **argv)
 
 	/* Create threads */
 	tids = (pthread_t *) malloc(sizeof(pthread_t)*numThreads);
-	for (i=0; i<numThreads; i++) {
+	for (i=0; i<numThreads; i++)
+	{
 		value = (int *) malloc(sizeof(int));
 		*value = i;
 		pthread_create(&tids[i], NULL, run, (void *) value);
 	}
 
 	/* Wait for all threads to finish */
-	for (i=0; i<numThreads; i++) {
+	for (i=0; i<numThreads; i++)
+	{
 		pthread_join(tids[i], NULL);
 	}
 
@@ -124,15 +131,19 @@ void *run(void *ptr)
 	/* Thread will read from file input_x.txt */
 	sprintf(filename, "transactions_%d.txt", id);
 	fp = fopen(filename, "r");
-	if(fp == NULL) {
+	if(fp == NULL)
+	{
 		fprintf(stderr, "Can't open input file %s\n", filename);
 		exit(1);
 	}
 
 	printf("Thread [%d]: Session started\n", id);
-	if(good == 1) {
+	if(good == 1)
+	{
 		goodSession(id, fp);
-	} else {
+	}
+	else
+	{
 		badSession(id, fp);
 	}
 	printf("Thread [%d]: Session ended\n", id);
@@ -149,12 +160,15 @@ void badSession(int id, FILE *fp)
 
 	/* This is not a good place to lock! */
 	pthread_mutex_lock(&(myacct->mutex));
-	while(fscanf(fp, "%lf", &amount) != EOF) {
-		if(amount < 1) {
+	while(fscanf(fp, "%lf", &amount) != EOF)
+	{
+		if(amount < 1)
+		{
 			sleep(30); // Simulates user walking away from machine.
 		}
 		deposit(myacct, amount); // Uses shared myacct variable.
-		printf("\tThread [%d]: Deposited: %f\n", id, amount); fflush(stdout);
+		printf("\tThread [%d]: Deposited: %f\n", id, amount);
+		fflush(stdout);
 	}
 	pthread_mutex_unlock(&(myacct->mutex));
 }
@@ -167,15 +181,18 @@ void goodSession(int id, FILE *fp)
 {
 	double amount;
 
-	while(fscanf(fp, "%lf", &amount) != EOF) {
-		if(amount < 1) {
+	while(fscanf(fp, "%lf", &amount) != EOF)
+	{
+		if(amount < 1)
+		{
 			sleep(30); // Simulates user walking away from machine.
 		}
 		/* lock around smallest chunk of code possible. */
 		pthread_mutex_lock(&(myacct->mutex));
 		deposit(myacct, amount); // Uses shared myacct variable.
 		pthread_mutex_unlock(&(myacct->mutex));
-		printf("\tThread [%d]: Deposited: %f\n", id, amount); fflush(stdout);
+		printf("\tThread [%d]: Deposited: %f\n", id, amount);
+		fflush(stdout);
 	}
 }
 

--- a/threads/safe-bank-balance.c
+++ b/threads/safe-bank-balance.c
@@ -15,7 +15,8 @@
 
 
 typedef struct account account;
-struct account {
+struct account
+{
 	double balance;
 	pthread_mutex_t mutex;
 };
@@ -30,14 +31,16 @@ int main(int argc, char **argv)
 {
 	int i;
 
-	if (argc < 2) {
+	if (argc < 2)
+	{
 		fprintf(stderr, "Usage: %s <numThreads> <iterations>\n", argv[0]);
 		exit(1);
 	}
 
 	numThreads  = atoi(argv[1]);
 	count = atoi(argv[2]);
-	if (numThreads > 32) {
+	if (numThreads > 32)
+	{
 		fprintf(stderr, "Usage: %s Too many threads  specified. Defaulting to 32.\n", argv[0]);
 		numThreads = 32;
 	}
@@ -48,15 +51,15 @@ int main(int argc, char **argv)
 	printf("initial balance = %lf\n", myacct->balance);
 
 
-    tids = (pthread_t *) malloc(sizeof(pthread_t)*numThreads);
-    for (i=0; i<numThreads; i++)
-        pthread_create(&tids[i], NULL, threadMain, (void *) NULL);
+	tids = (pthread_t *) malloc(sizeof(pthread_t)*numThreads);
+	for (i=0; i<numThreads; i++)
+		pthread_create(&tids[i], NULL, threadMain, (void *) NULL);
 
-    for (i=0; i<numThreads; i++)
-        pthread_join(tids[i], NULL);
+	for (i=0; i<numThreads; i++)
+		pthread_join(tids[i], NULL);
 
 	printf("final balance = %lf\n", myacct->balance);
-    exit(0);
+	exit(0);
 }
 
 void *threadMain(void *arg)
@@ -64,7 +67,8 @@ void *threadMain(void *arg)
 	int i;
 	int amount;
 
-	for (i=0; i<count; i++) {
+	for (i=0; i<count; i++)
+	{
 		amount = 1;
 		pthread_mutex_lock(&(myacct->mutex));
 		myacct->balance += amount;

--- a/threads/seq-sum.c
+++ b/threads/seq-sum.c
@@ -5,19 +5,19 @@
 #include <pthread.h>
 #include <string.h>
 
-void *partial_sum(void *ptr); 
+void *partial_sum(void *ptr);
 int *values;
 int n;
 int result[2]; /* partial sums arrays */
 
 float report_cpu_time();
-  
+
 int  main( int argc, char **argv)
 {
 	int i;
 	long sum;
 	float start_time, total_time;
-     
+
 	if (argc != 2)
 	{
 		fprintf(stderr, "Usage: %s <n> \n", argv[0]);
@@ -30,13 +30,14 @@ int  main( int argc, char **argv)
 
 	start_time = report_cpu_time();
 	sum = 0;
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		sum += values[i];
 	}
 	total_time = report_cpu_time() - start_time;
 
 	printf("Total sum = %ld time taken = %lf seconds \n", sum, total_time);
-    exit(0);
+	exit(0);
 }
 
 

--- a/threads/thread-better-hello-world.c
+++ b/threads/thread-better-hello-world.c
@@ -4,29 +4,29 @@
 #include <stdio.h>
 #include <pthread.h>
 
-  void *print_message_function( void *ptr ); 
-  
+void *print_message_function( void *ptr );
+
 int  main()
 {
-     pthread_t thread1, thread2;
-     char *message1 = "Goodbye";
-     char *message2 = "World";
-     
-     pthread_create( &thread1, NULL,
-                    print_message_function, (void*) message1);
-	 /*sleep(1);*/
-     pthread_create(&thread2, NULL, 
-                    print_message_function, (void*) message2);
-  
-	 pthread_join(thread2, NULL); /* wait for thread2 to finish */
-	 pthread_join(thread1, NULL); /* wait for thread1 to finish */
-     exit(0);
+	pthread_t thread1, thread2;
+	char *message1 = "Goodbye";
+	char *message2 = "World";
+
+	pthread_create( &thread1, NULL,
+	                print_message_function, (void*) message1);
+	/*sleep(1);*/
+	pthread_create(&thread2, NULL,
+	               print_message_function, (void*) message2);
+
+	pthread_join(thread2, NULL); /* wait for thread2 to finish */
+	pthread_join(thread1, NULL); /* wait for thread1 to finish */
+	exit(0);
 }
 
 void *print_message_function( void *ptr )
 {
-    char *message;
-    message = (char *) ptr;
-    printf("%s ", message);
+	char *message;
+	message = (char *) ptr;
+	printf("%s ", message);
 	pthread_exit(NULL);
 }

--- a/threads/thread-big-calc.c
+++ b/threads/thread-big-calc.c
@@ -9,37 +9,39 @@
 #include <pthread.h>
 #include <math.h>
 
-void *run( void *ptr ); 
+void *run( void *ptr );
 int *results;
 long max;
 long n;
-  
+
 int main(int argc, char **argv)
 {
 	int i;
 	int *value;
-    pthread_t *tid; 
-     
-	if (argc != 3) {
-	 	fprintf(stderr, "Usage: thread-ids <num-threads> <max>\n");
+	pthread_t *tid;
+
+	if (argc != 3)
+	{
+		fprintf(stderr, "Usage: thread-ids <num-threads> <max>\n");
 		exit(EXIT_FAILURE);
 	}
 	n = atoi(argv[1]);
 	max = atoll(argv[2]);
 	tid = (pthread_t *) malloc(sizeof(pthread_t) * n);
 	results = (int *) malloc(sizeof(int) * n);
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		value = (int *) malloc(sizeof(int));
 		*value = i+1;
-    	pthread_create(&tid[i], NULL, run, (void *) value);
+		pthread_create(&tid[i], NULL, run, (void *) value);
 	}
-  
-	for (i=0; i<n; i++)
-     	pthread_join(tid[i], NULL);
 
-    exit(EXIT_SUCCESS);
+	for (i=0; i<n; i++)
+		pthread_join(tid[i], NULL);
+
+	exit(EXIT_SUCCESS);
 }
-  
+
 void *run(void *ptr)
 {
 	long i;

--- a/threads/thread-cp.c
+++ b/threads/thread-cp.c
@@ -1,9 +1,9 @@
- 
-/* 
+
+/*
  * A simple attempt to the synchronization problem that works for
  * most cases but is not guaranteed to work.
- * 
- */ 
+ *
+ */
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -35,88 +35,94 @@ int flag=READ;
 void *reader(void *);
 void *writer(void *);
 
-  
+
 int main(int argc, char *argv[])
 {
-    pthread_t thread1, thread2;
+	pthread_t thread1, thread2;
 
-    if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr,"Usage: %s <buffer size> <src> <dest>\n", argv[0]);
 		exit(EX_USAGE);
-	}		
-	
+	}
+
 	bufsize = atoi(argv[1]);
-	if (bufsize > MAX_BUF_SIZE) {
+	if (bufsize > MAX_BUF_SIZE)
+	{
 		fprintf(stderr,"Error: %s: max. buffer size is MAX_BUF_SIZE\n",argv[0]);
 		exit(EX_USAGE);
-	}	
+	}
 
-    src = open(argv[2], O_RDONLY);
-    if (src < 0) exit(EX_NOINPUT);
-    dst = creat(argv[3], MODE);
-    if (dst < 0) exit(EX_CANTCREAT);
-	
+	src = open(argv[2], O_RDONLY);
+	if (src < 0) exit(EX_NOINPUT);
+	dst = creat(argv[3], MODE);
+	if (dst < 0) exit(EX_CANTCREAT);
+
 	/* create the reader and writer threads */
 
-    pthread_create(&thread1, NULL, reader, (void*) NULL);
-    pthread_create(&thread2, NULL, writer, (void*) NULL);
+	pthread_create(&thread1, NULL, reader, (void*) NULL);
+	pthread_create(&thread2, NULL, writer, (void*) NULL);
 
 	/* the main program (i.e. the heavyweight parent process) waits
 	 * for the threads to finish.
-	 */ 
-    pthread_join(thread1, NULL);
-    pthread_join(thread2, NULL);
+	 */
+	pthread_join(thread1, NULL);
+	pthread_join(thread2, NULL);
 
-    close(src);
-    close(dst);
-    exit(EXIT_SUCCESS);
+	close(src);
+	close(dst);
+	exit(EXIT_SUCCESS);
 }
-  
 
-/* 
- * reader(): The function reader() is the entire reader thread. It 
+
+/*
+ * reader(): The function reader() is the entire reader thread. It
  * synchronizes with the writer thread, which execute the writer() function.
- */ 
+ */
 void *reader(void *arg)
 {
-    printf("Reader thread, file = %d\n",src);
-    fflush(stdout);
-    while (1) {
-        if (flag == READ) {  
-            in = read(src, buf, bufsize);
-#ifdef DEBUG			
-            printf("read %d character\n",in);
+	printf("Reader thread, file = %d\n",src);
+	fflush(stdout);
+	while (1)
+	{
+		if (flag == READ)
+		{
+			in = read(src, buf, bufsize);
+#ifdef DEBUG
+			printf("read %d character\n",in);
 			fflush(stdout);
 #endif
-            flag = WRITE;
-        	if (in <= 0) break;
-        }       
+			flag = WRITE;
+			if (in <= 0) break;
+		}
 		/*usleep(10000); // 1/100th sec*/
-    }
-    pthread_exit(0);
+	}
+	pthread_exit(0);
 }
 
 
 
 /*
- * 
+ *
  * writer(): The main function for the writer thread.
- */ 
-void *writer(void *arg) 
+ */
+void *writer(void *arg)
 {
-    printf("Writer thread, file = %d\n",dst);
-    fflush(stdout);
-    while (1) {
-        if (flag == WRITE) {
-            out = write(dst, buf, in);
-#ifdef DEBUG			
-            printf("wrote %d character\n",out);
+	printf("Writer thread, file = %d\n",dst);
+	fflush(stdout);
+	while (1)
+	{
+		if (flag == WRITE)
+		{
+			out = write(dst, buf, in);
+#ifdef DEBUG
+			printf("wrote %d character\n",out);
 			fflush(stdout);
 #endif
-            flag = READ;
-        	if (out <= 0) break;
-        }   
+			flag = READ;
+			if (out <= 0) break;
+		}
 		/*usleep(10000); // 1/100th sec*/
-    }
-    pthread_exit(0);
+	}
+	pthread_exit(0);
 }

--- a/threads/thread-dbl-buf-attempt.c
+++ b/threads/thread-dbl-buf-attempt.c
@@ -1,8 +1,8 @@
- 
-/* 
+
+/*
  * A simple WRONG attempt to uses double buffering to increase concurrency for the reader/writer threads.
- * 
- */ 
+ *
+ */
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -36,79 +36,89 @@ int readStarted=FALSE;
 void reader(void);
 void writer(void);
 
-  
+
 int main(int argc, char *argv[])
 {
-    pthread_t thread1, thread2;
+	pthread_t thread1, thread2;
 
-    if (argc != 4) {
+	if (argc != 4)
+	{
 		fprintf(stderr,"Usage: %s <buffer size> <src> <dest>\n", argv[0]);
 		exit(1);
-	}		
-	
+	}
+
 	bufsize = atoi(argv[1]);
-	if (bufsize > 8192) {
+	if (bufsize > 8192)
+	{
 		fprintf(stderr,"Error: %s: max. buffer size is MAX_BUF_SIZE\n",argv[0]);
 		exit(1);
-	}	
+	}
 
 
-    src = open(argv[2], O_RDONLY);
-    if (src < 0) exit(2);
-    dst = creat(argv[3], MODE);
-    if (dst < 0) exit(3);
-	
+	src = open(argv[2], O_RDONLY);
+	if (src < 0) exit(2);
+	dst = creat(argv[3], MODE);
+	if (dst < 0) exit(3);
+
 	readbuffer = bufA;
 	writebuffer = bufB;
 
-    pthread_create(&thread1, NULL, (void*)&reader, (void*) NULL);
-    pthread_create(&thread2, NULL, (void*)&writer, (void*) NULL);
+	pthread_create(&thread1, NULL, (void*)&reader, (void*) NULL);
+	pthread_create(&thread2, NULL, (void*)&writer, (void*) NULL);
 
-  
-    pthread_join(thread1, NULL);
-    pthread_join(thread2, NULL);
 
-    close(src);
-    close(dst);
-    exit(0);
+	pthread_join(thread1, NULL);
+	pthread_join(thread2, NULL);
+
+	close(src);
+	close(dst);
+	exit(0);
 }
-  
+
 void reader(void)
 {
 	char *tmp;
 
-    printf("Reader thread, file = %d\n",src);
-    fflush(stdout);
-    while (1) {
-        in = read(src, readbuffer, bufsize);
+	printf("Reader thread, file = %d\n",src);
+	fflush(stdout);
+	while (1)
+	{
+		in = read(src, readbuffer, bufsize);
 		readStarted=TRUE;
-        /*printf("read %d character\n",in);*/
-        if (!(flag)) {  
-			tmp = readbuffer; readbuffer=writebuffer; writebuffer=tmp;   
-            flag = TRUE;
-        }       
-        if (in <= 0) break;
-    }
-    pthread_exit(0);
+		/*printf("read %d character\n",in);*/
+		if (!(flag))
+		{
+			tmp = readbuffer;
+			readbuffer=writebuffer;
+			writebuffer=tmp;
+			flag = TRUE;
+		}
+		if (in <= 0) break;
+	}
+	pthread_exit(0);
 }
 
-void writer(void) 
+void writer(void)
 {
 	char *tmp;
 
-    printf("Writer thread, file = %d\n",dst);
-    fflush(stdout);
+	printf("Writer thread, file = %d\n",dst);
+	fflush(stdout);
 
 	while (!readStarted);
-	
-    while (1) {
-        out = write(dst, writebuffer, in);
-        /*printf("wrote %d character\n",out);*/
-        if (flag) {
-			tmp = readbuffer; readbuffer=writebuffer; writebuffer=tmp;   
-            flag = FALSE;
-        }   
-        if (out <= 0) break;
-    }
-    pthread_exit(0);
+
+	while (1)
+	{
+		out = write(dst, writebuffer, in);
+		/*printf("wrote %d character\n",out);*/
+		if (flag)
+		{
+			tmp = readbuffer;
+			readbuffer=writebuffer;
+			writebuffer=tmp;
+			flag = FALSE;
+		}
+		if (out <= 0) break;
+	}
+	pthread_exit(0);
 }

--- a/threads/thread-ex.c
+++ b/threads/thread-ex.c
@@ -1,8 +1,8 @@
- 
-/* 
+
+/*
  *
   Create three threads to see how they are scheduled.
- */ 
+ */
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,28 +11,29 @@
 
 
 void *run(void *);
-  
+
 int main(int argc, char *argv[])
 {
-    pthread_t merlot, pinot, cabernet;
+	pthread_t merlot, pinot, cabernet;
 
-    pthread_create(&merlot, NULL, run, (void*) "merlot");
-    pthread_create(&pinot, NULL, run, (void*) "pinot");
-    pthread_create(&cabernet, NULL, run, (void*) "cabernet");
+	pthread_create(&merlot, NULL, run, (void*) "merlot");
+	pthread_create(&pinot, NULL, run, (void*) "pinot");
+	pthread_create(&cabernet, NULL, run, (void*) "cabernet");
 
-	/* the main program waits for the threads to finish. */ 
-    pthread_join(merlot, NULL);
-    pthread_join(pinot, NULL);
-    pthread_join(cabernet, NULL);
+	/* the main program waits for the threads to finish. */
+	pthread_join(merlot, NULL);
+	pthread_join(pinot, NULL);
+	pthread_join(cabernet, NULL);
 	exit(EXIT_SUCCESS);
 }
 
-  
-void *run(void *arg) 
+
+void *run(void *arg)
 {
 	char *name = (char *)arg;
 	int i;
-	for (i=0; i<500000; i++) {
+	for (i=0; i<500000; i++)
+	{
 		printf("This is the %s thread\n",name);
 	}
 	pthread_exit(NULL);

--- a/threads/thread-hello-world.c
+++ b/threads/thread-hello-world.c
@@ -11,27 +11,27 @@ gcc threads-hello-world.c -lpthread
 #include <stdio.h>
 #include <pthread.h>
 
-void *print_message_function( void *ptr ); 
-  
+void *print_message_function( void *ptr );
+
 int  main()
 {
-     pthread_t thread1, thread2;
-     char *message1 = "Goodbye";
-     char *message2 = "World";
-     
-     pthread_create(&thread1, NULL, print_message_function, (void*) message1);
-     pthread_create(&thread2, NULL, print_message_function, (void*) message2);
-	 /*sleep(1);*/
-  
-	 /*pause();*/
-     exit(EXIT_SUCCESS);
+	pthread_t thread1, thread2;
+	char *message1 = "Goodbye";
+	char *message2 = "World";
+
+	pthread_create(&thread1, NULL, print_message_function, (void*) message1);
+	pthread_create(&thread2, NULL, print_message_function, (void*) message2);
+	/*sleep(1);*/
+
+	/*pause();*/
+	exit(EXIT_SUCCESS);
 }
-  
+
 void *print_message_function(void *ptr)
 {
-     char *message;
-     message = (char *) ptr;
-     printf("%s ", message);
-	 /*pause();*/
-	 pthread_exit(NULL);
+	char *message;
+	message = (char *) ptr;
+	printf("%s ", message);
+	/*pause();*/
+	pthread_exit(NULL);
 }

--- a/threads/thread-ids.c
+++ b/threads/thread-ids.c
@@ -11,32 +11,34 @@ gcc threads-hello-world.c -lpthread
 #include <stdio.h>
 #include <pthread.h>
 
-void *run( void *ptr ); 
-  
+void *run( void *ptr );
+
 int main(int argc, char **argv)
 {
 	int i, n;
 	int *value;
-    pthread_t *tid; 
-     
-	if (argc != 2) {
-	 	fprintf(stderr, "Usage: thread-ids <num-threads>\n");
+	pthread_t *tid;
+
+	if (argc != 2)
+	{
+		fprintf(stderr, "Usage: thread-ids <num-threads>\n");
 		exit(EXIT_FAILURE);
 	}
 	n = atoi(argv[1]);
 	tid = (pthread_t *) malloc(sizeof(pthread_t) * n);
-	for (i=0; i<n; i++) {
+	for (i=0; i<n; i++)
+	{
 		value = (int *) malloc(sizeof(int));
 		*value = i;
-    	pthread_create(&tid[i], NULL, run, (void *) value);
+		pthread_create(&tid[i], NULL, run, (void *) value);
 	}
-  
-	for (i=0; i<n; i++)
-     	pthread_join(tid[i], NULL);
 
-    exit(EXIT_SUCCESS);
+	for (i=0; i<n; i++)
+		pthread_join(tid[i], NULL);
+
+	exit(EXIT_SUCCESS);
 }
-  
+
 void *run(void *ptr)
 {
 	printf("I am thread %d with thread id %X\n", *(int *)ptr, (unsigned int) pthread_self());

--- a/threads/thread-scheduling.c
+++ b/threads/thread-scheduling.c
@@ -1,38 +1,39 @@
 
 /* To compile this program under Linux
- * 
+ *
  * gcc threads-hello-world.c -lpthread -lm
- * 
+ *
  * Creates two threads that compute for a long time. Good way
  * to check how threads are scheduled on a two-cpu machine.
- * 
-*/  
+ *
+*/
 
 #include <pthread.h>
 #include <math.h>
 
-  
-  main()
-  {
-     pthread_t thread1, thread2;
-	 void compute_until_hell_freezes();
-     
-     pthread_create( &thread1, NULL,
-                    (void*)&compute_until_hell_freezes, NULL);
-     pthread_create(&thread2, NULL, 
-                    (void*)&compute_until_hell_freezes, NULL);
-  
-	 pthread_join(thread1, NULL);
-	 pthread_join(thread2, NULL);
-     exit(0);
-  }
-  
-  void compute_until_hell_freezes()
-  {
+
+main()
+{
+	pthread_t thread1, thread2;
+	void compute_until_hell_freezes();
+
+	pthread_create( &thread1, NULL,
+	                (void*)&compute_until_hell_freezes, NULL);
+	pthread_create(&thread2, NULL,
+	               (void*)&compute_until_hell_freezes, NULL);
+
+	pthread_join(thread1, NULL);
+	pthread_join(thread2, NULL);
+	exit(0);
+}
+
+void compute_until_hell_freezes()
+{
 	int i;
 	double tmp;
 
-	for (i=0; i<90000000; i++) {
+	for (i=0; i<90000000; i++)
+	{
 		tmp = sqrt((double) i);
 	}
-  }
+}

--- a/threads/thread-sum.c
+++ b/threads/thread-sum.c
@@ -58,11 +58,14 @@ void *partial_sum(void *ptr)
 	printf("%s ", message);
 
 	sum = 0;
-	if (strcmp(message,"1") == 0)  {
+	if (strcmp(message,"1") == 0)
+	{
 		index = 0;
 		start = 0;
 		end = n/2;
-	} else {
+	}
+	else
+	{
 		index = 1;
 		start = n/2 + 1;
 		end = n - 1;

--- a/threads/thread-test.c
+++ b/threads/thread-test.c
@@ -1,10 +1,10 @@
- 
-/* 
- Check limit on user processes/threads with 
+
+/*
+ Check limit on user processes/threads with
    ulimit -a
  May cause system to be unusable for a short time if you exceed limit!!
  Try it as root to see if you can get more resources.
- */ 
+ */
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -14,7 +14,7 @@
 void *run(void *);
 
 #define MAX 10000
-  
+
 int main(int argc, char *argv[])
 {
 	int i, status;
@@ -23,8 +23,9 @@ int main(int argc, char *argv[])
 
 	for (i=0; i<MAX; i++)
 	{
-    	status  = pthread_create(&tids[i], NULL, run, (void*) NULL );
-		if (status != 0) {
+		status  = pthread_create(&tids[i], NULL, run, (void*) NULL );
+		if (status != 0)
+		{
 			perror("thread-test");
 			break;
 		}
@@ -35,14 +36,14 @@ int main(int argc, char *argv[])
 
 	for (i=0; i<count; i++)
 	{
-    	pthread_join(tids[i], NULL);
+		pthread_join(tids[i], NULL);
 	}
 
 	exit(0);
 }
 
-  
-void *run(void *arg) 
+
+void *run(void *arg)
 {
 	printf("This is  thread id = %X\n",pthread_self());
 	sleep(30);

--- a/threads/timing.c
+++ b/threads/timing.c
@@ -11,24 +11,24 @@
 clock_t times(struct tms *buffer);
 
 times() fills the structure pointed to by buffer with
-time-accounting information.  The structure defined in 
+time-accounting information.  The structure defined in
 <sys/times.h> is as follows:
 
 struct tms {
-    clock_t tms_utime;       user time 
-    clock_t tms_stime;       system time 
-    clock_t tms_cutime;      user time, children 
-    clock_t tms_cstime;      system time, children 
+    clock_t tms_utime;       user time
+    clock_t tms_stime;       system time
+    clock_t tms_cutime;      user time, children
+    clock_t tms_cstime;      system time, children
 
 The time is given in units of 1/CLK_TCK seconds where the
 value of CLK_TCK can be determined using the sysconf() function
 with the agrgument _SC_CLK_TCK.
 ---------------------------------------------------------------------------
 */
-								  
+
 
 float report_cpu_time()
-{ 
+{
 	struct tms buffer;
 	float cputime;
 
@@ -39,7 +39,7 @@ float report_cpu_time()
 
 
 float report_sys_time()
-{ 
+{
 	struct tms buffer;
 	float systime;
 
@@ -50,8 +50,8 @@ float report_sys_time()
 
 double getMilliSeconds()
 {
-    struct timeval now;
-    gettimeofday(&now, (struct timezone *)0);
-    return (double) now.tv_sec*1000.0 + now.tv_usec/1000.0;
+	struct timeval now;
+	gettimeofday(&now, (struct timezone *)0);
+	return (double) now.tv_sec*1000.0 + now.tv_usec/1000.0;
 }
 

--- a/timing.c
+++ b/timing.c
@@ -11,24 +11,24 @@
 clock_t times(struct tms *buffer);
 
 times() fills the structure pointed to by buffer with
-time-accounting information.  The structure defined in 
+time-accounting information.  The structure defined in
 <sys/times.h> is as follows:
 
 struct tms {
-    clock_t tms_utime;       user time 
-    clock_t tms_stime;       system time 
-    clock_t tms_cutime;      user time, children 
-    clock_t tms_cstime;      system time, children 
+    clock_t tms_utime;       user time
+    clock_t tms_stime;       system time
+    clock_t tms_cutime;      user time, children
+    clock_t tms_cstime;      system time, children
 
 The time is given in units of 1/CLK_TCK seconds where the
 value of CLK_TCK can be determined using the sysconf() function
 with the agrgument _SC_CLK_TCK.
 ---------------------------------------------------------------------------
 */
-								  
+
 
 float report_cpu_time()
-{ 
+{
 	struct tms buffer;
 	float cputime;
 
@@ -39,7 +39,7 @@ float report_cpu_time()
 
 
 float report_sys_time()
-{ 
+{
 	struct tms buffer;
 	float systime;
 
@@ -50,8 +50,8 @@ float report_sys_time()
 
 double getMilliSeconds()
 {
-    struct timeval now;
-    gettimeofday(&now, (struct timezone *)0);
-    return (double) now.tv_sec*1000.0 + now.tv_usec/1000.0;
+	struct timeval now;
+	gettimeofday(&now, (struct timezone *)0);
+	return (double) now.tv_sec*1000.0 + now.tv_usec/1000.0;
 }
 


### PR DESCRIPTION
A complement to shanep/vim#1.

Formatted using the allman style (I personally prefer K&R but it looks as if you were going for Allman). Also formatted with tabs; can switch to spaces if you so prefer.

Make has same output as before, though there were some build errors (Mac OSX Yosemite) - I've included my Clang/GCC version information if you need it, though I have a sneaking suspicion there are supposed to be errors. :+1:

```
$ clang --version
Apple LLVM version 6.1.0 (clang-602.0.53) (based on LLVM 3.6.0svn)
Target: x86_64-apple-darwin14.1.0
Thread model: posix

$ gcc --version
gcc (Homebrew gcc 4.9.2_1) 4.9.2
- richard stallman snip -

$ ld -v
@(#)PROGRAM:ld  PROJECT:ld64-242.2
configured to support archs: armv6 armv7 armv7s arm64 i386 x86_64 x86_64h armv6m armv7m armv7em
LTO support using: LLVM version 3.6.0svn
```

Note that `-shared` doesn't exist on Mac OSX. I can submit another PR that fixes it, unless that's a course obstacle. 
